### PR TITLE
Feature/zeveisenberg/10 text alignment

### DIFF
--- a/Example/BonMot.xcodeproj/project.pbxproj
+++ b/Example/BonMot.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		CDD4B9EE1AEB2C3F00B02A0A /* ColorCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CDD4B9EC1AEB2C3F00B02A0A /* ColorCell.xib */; };
 		CDDFD7EC1B7F9D4700A87008 /* IndentationCell.m in Sources */ = {isa = PBXBuildFile; fileRef = CDDFD7EA1B7F9D4700A87008 /* IndentationCell.m */; };
 		CDDFD7ED1B7F9D4700A87008 /* IndentationCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CDDFD7EB1B7F9D4700A87008 /* IndentationCell.xib */; };
+		CDEEF16B1BE400BF00A237EC /* BONTextAlignmentTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = CDEEF16A1BE400BF00A237EC /* BONTextAlignmentTestCase.m */; };
 		CDFC93B81AE59FCA00C2B7C9 /* EBGaramond12-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = CDFC93B71AE59FCA00C2B7C9 /* EBGaramond12-Regular.otf */; };
 		CDFCA9E11B5078E0000E47DB /* BONBaseTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = CDFCA9E01B5078E0000E47DB /* BONBaseTestCase.m */; };
 		CDFDF5511B51880D00A1AD42 /* NSDictionary+BONEquality.m in Sources */ = {isa = PBXBuildFile; fileRef = CDFDF5501B51880D00A1AD42 /* NSDictionary+BONEquality.m */; };
@@ -143,6 +144,7 @@
 		CDDFD7E91B7F9D4700A87008 /* IndentationCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IndentationCell.h; sourceTree = "<group>"; };
 		CDDFD7EA1B7F9D4700A87008 /* IndentationCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IndentationCell.m; sourceTree = "<group>"; };
 		CDDFD7EB1B7F9D4700A87008 /* IndentationCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IndentationCell.xib; sourceTree = "<group>"; };
+		CDEEF16A1BE400BF00A237EC /* BONTextAlignmentTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BONTextAlignmentTestCase.m; sourceTree = "<group>"; };
 		CDFC93B71AE59FCA00C2B7C9 /* EBGaramond12-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "EBGaramond12-Regular.otf"; sourceTree = "<group>"; };
 		CDFC93B91AE5A17100C2B7C9 /* EB Garamond License.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "EB Garamond License.txt"; sourceTree = "<group>"; };
 		CDFCA9E01B5078E0000E47DB /* BONBaseTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BONBaseTestCase.m; sourceTree = "<group>"; };
@@ -257,6 +259,7 @@
 				CDB7D3581BC86FF8006B842F /* BONChainableTestCase.m */,
 				CDAB918B1B5F2A410023E432 /* BONTextAlignmentConstraintTestCase.m */,
 				720F06351BD819400077DC84 /* BONChainEmptyStringTestCase.m */,
+				CDEEF16A1BE400BF00A237EC /* BONTextAlignmentTestCase.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -588,6 +591,7 @@
 			files = (
 				CDFDF5521B51880D00A1AD42 /* NSDictionary+BONEquality.m in Sources */,
 				CDB7D35B1BC88C05006B842F /* BONPropertyClobberingTestCase.m in Sources */,
+				CDEEF16B1BE400BF00A237EC /* BONTextAlignmentTestCase.m in Sources */,
 				CDFDF5541B518F3900A1AD42 /* BONDictionaryEqualityTestCase.m in Sources */,
 				CDFCA9E11B5078E0000E47DB /* BONBaseTestCase.m in Sources */,
 				CDB7D3591BC86FF8006B842F /* BONChainableTestCase.m in Sources */,

--- a/Example/Tests/BONTextAlignmentTestCase.m
+++ b/Example/Tests/BONTextAlignmentTestCase.m
@@ -87,7 +87,7 @@
     NSParagraphStyle *testParagraphStyle = testAttributes[NSParagraphStyleAttributeName];
     XCTAssertNotNil(testParagraphStyle);
     XCTAssertEqual(testParagraphStyle.alignment, NSTextAlignmentCenter);
-    XCTAssertEqual(testParagraphStyle.lineHeightMultiple, 3.14);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.lineHeightMultiple, 3.14, kBONCGFloatEpsilon);
 }
 
 @end

--- a/Example/Tests/BONTextAlignmentTestCase.m
+++ b/Example/Tests/BONTextAlignmentTestCase.m
@@ -1,0 +1,93 @@
+//
+//  BONTextAlignmentTestCase.m
+//  BonMot
+//
+//  Created by Zev Eisenberg on 10/30/15.
+//  Copyright © 2015 Zev Eisenberg. All rights reserved.
+//
+
+#import "BONBaseTestCase.h"
+#import <BONMot/BonMot.h>
+
+@interface BONTextAlignmentTestCase : BONBaseTestCase
+
+@end
+
+@implementation BONTextAlignmentTestCase
+
+
+- (void)testDefaultAlignmentOfText
+{
+    BONText *text = [[BONText alloc] init];
+    XCTAssertEqual(text.alignment, NSTextAlignmentNatural);
+
+    text = BONText.new;
+    XCTAssertEqual(text.alignment, NSTextAlignmentNatural);
+
+    text.alignment = NSTextAlignmentRight;
+    XCTAssertEqual(text.alignment, NSTextAlignmentRight);
+}
+
+- (void)testDefaultAlignmentOfChain
+{
+    NSAttributedString *string = BONChain.new.string(@"E pur si muove").attributedString;
+
+    NSParagraphStyle *defaultParagraphStyle = [[NSParagraphStyle alloc] init];
+
+    NSDictionary *controlAttributes = @{
+                                        BONValueFromRange(0, 14): @{
+                                                NSParagraphStyleAttributeName: defaultParagraphStyle,
+                                                },
+                                        };
+
+    BONAssertAttributedStringHasAttributes(string, controlAttributes);
+}
+
+- (void)testAdjustedAlignment
+{
+    BONChain *chain = BONChain.new.string(@"E pur si muove").alignment(NSTextAlignmentCenter);
+    NSAttributedString *string = chain.attributedString;
+
+    NSMutableParagraphStyle *controlParagraphStyle = [[NSMutableParagraphStyle alloc] init];
+    controlParagraphStyle.alignment = NSTextAlignmentCenter;
+
+    NSDictionary *controlAttributes = @{
+                                        BONValueFromRange(0, 14): @{
+                                                NSParagraphStyleAttributeName: controlParagraphStyle,
+                                                },
+                                        };
+
+    BONAssertAttributedStringHasAttributes(string, controlAttributes);
+
+    NSDictionary *testAttributes = chain.attributes;
+    NSParagraphStyle *testParagraphStyle = testAttributes[NSParagraphStyleAttributeName];
+    XCTAssertNotNil(testParagraphStyle);
+    XCTAssertEqual(testParagraphStyle.alignment, NSTextAlignmentCenter);
+}
+
+// Test setting both line height multiple and alignment, since they both affect the paragraph style
+- (void)testMixingAlignmentAndLineHeightMultiple
+{
+    BONChain *chain = BONChain.new.string(@"E pluribus unum").alignment(NSTextAlignmentCenter).lineHeightMultiple(3.14);
+    NSAttributedString *string = chain.attributedString;
+
+    NSMutableParagraphStyle *controlParagraphStyle = [[NSMutableParagraphStyle alloc] init];
+    controlParagraphStyle.alignment = NSTextAlignmentCenter;
+    controlParagraphStyle.lineHeightMultiple = 3.14;
+
+    NSDictionary *controlAttributes = @{
+                                        BONValueFromRange(0, 15): @{
+                                                NSParagraphStyleAttributeName: controlParagraphStyle,
+                                                },
+                                        };
+
+    BONAssertAttributedStringHasAttributes(string, controlAttributes);
+
+    NSDictionary *testAttributes = chain.attributes;
+    NSParagraphStyle *testParagraphStyle = testAttributes[NSParagraphStyleAttributeName];
+    XCTAssertNotNil(testParagraphStyle);
+    XCTAssertEqual(testParagraphStyle.alignment, NSTextAlignmentCenter);
+    XCTAssertEqual(testParagraphStyle.lineHeightMultiple, 3.14);
+}
+
+@end

--- a/Pod/Classes/BONChain.h
+++ b/Pod/Classes/BONChain.h
@@ -19,6 +19,7 @@ typedef BONChain*(^BONChainAdobeTracking)(NSInteger adobeTracking);
 typedef BONChain*(^BONChainPointTracking)(CGFloat pointTracking);
 typedef BONChain*(^BONChainLineHeight)(CGFloat lineHeightMultiple);
 typedef BONChain*(^BONChainBaselineOffset)(CGFloat baselineOffset);
+typedef BONChain*(^BONChainAlignment)(NSTextAlignment alignment);
 typedef BONChain*(^BONChainFigureCase)(BONFigureCase figureCase);
 typedef BONChain*(^BONChainFigureSpacing)(BONFigureSpacing figureSpacing);
 typedef BONChain*(^BONChainIndentSpacer)(CGFloat indentSpacer);
@@ -45,6 +46,8 @@ typedef BONChain*(^BONChainImage)(UIImage *image);
 @property (copy, nonatomic, readonly) BONChainLineHeight lineHeightMultiple;
 
 @property (copy, nonatomic, readonly) BONChainBaselineOffset baselineOffset;
+
+@property (copy, nonatomic, readonly) BONChainAlignment alignment;
 
 @property (copy, nonatomic, readonly) BONChainFigureCase figureCase;
 @property (copy, nonatomic, readonly) BONChainFigureSpacing figureSpacing;

--- a/Pod/Classes/BONChain.m
+++ b/Pod/Classes/BONChain.m
@@ -144,6 +144,17 @@
     return [baselineOffsetBlock copy];
 }
 
+- (BONChainAlignment)alignment
+{
+    BONChainAlignment alignmentBlock = ^(NSTextAlignment alignment) {
+        __typeof(self) newChain = self.copyWithoutNextText;
+        newChain.text.alignment = alignment;
+        return newChain;
+    };
+
+    return [alignmentBlock copy];
+}
+
 - (BONChainFigureCase)figureCase
 {
     BONChainFigureCase figureCaseBlock = ^(BONFigureCase figureCase) {

--- a/Pod/Classes/BONChain.m
+++ b/Pod/Classes/BONChain.m
@@ -57,7 +57,7 @@
 - (BONChainFontNameAndSize)fontNameAndSize
 {
     BONChainFontNameAndSize fontNameAndSizeBlock = ^(NSString *fontName, CGFloat fontSize) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         UIFont *font = [UIFont fontWithName:fontName size:fontSize];
         NSAssert(font, @"No font returned from [UIFont fontWithName:%@ size:%@]", fontName, @(fontSize));
         newChain.text.font = font;
@@ -70,7 +70,7 @@
 - (BONChainFont)font
 {
     BONChainFont fontBlock = ^(UIFont *font) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.font = font;
         return newChain;
     };
@@ -81,7 +81,7 @@
 - (BONChainColor)textColor
 {
     BONChainColor colorBlock = ^(UIColor *color) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.textColor = color;
         return newChain;
     };
@@ -92,7 +92,7 @@
 - (BONChainColor)backgroundColor
 {
     BONChainColor colorBlock = ^(UIColor *color) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.backgroundColor = color;
         return newChain;
     };
@@ -103,7 +103,7 @@
 - (BONChainAdobeTracking)adobeTracking
 {
     BONChainAdobeTracking adobeTrackingBlock = ^(NSInteger adobeTracking) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.adobeTracking = adobeTracking;
         return newChain;
     };
@@ -114,7 +114,7 @@
 - (BONChainPointTracking)pointTracking
 {
     BONChainPointTracking pointTrackingBlock = ^(CGFloat pointTracking) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.pointTracking = pointTracking;
         return newChain;
     };
@@ -125,7 +125,7 @@
 - (BONChainLineHeight)lineHeightMultiple
 {
     BONChainLineHeight lineHeightMultipleBlock = ^(CGFloat lineHeightMultiple) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.lineHeightMultiple = lineHeightMultiple;
         return newChain;
     };
@@ -136,7 +136,7 @@
 - (BONChainBaselineOffset)baselineOffset
 {
     BONChainBaselineOffset baselineOffsetBlock = ^(CGFloat baselineOffset) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.baselineOffset = baselineOffset;
         return newChain;
     };
@@ -147,7 +147,7 @@
 - (BONChainFigureCase)figureCase
 {
     BONChainFigureCase figureCaseBlock = ^(BONFigureCase figureCase) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.figureCase = figureCase;
         return newChain;
     };
@@ -158,7 +158,7 @@
 - (BONChainFigureSpacing)figureSpacing
 {
     BONChainFigureSpacing figureSpacingBlock = ^(BONFigureSpacing figureSpacing) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.figureSpacing = figureSpacing;
         return newChain;
     };
@@ -169,7 +169,7 @@
 - (BONChainString)string
 {
     BONChainString stringBlock = ^(NSString *string) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.string = string;
         return newChain;
     };
@@ -180,7 +180,7 @@
 - (BONChainImage)image
 {
     BONChainImage imageBlock = ^(UIImage *image) {
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.image = image;
         return newChain;
     };
@@ -192,7 +192,7 @@
 {
     BONChainIndentSpacer indentSpacerBlock = ^(CGFloat indentSpacer) {
         NSAssert(indentSpacer > 0.0f, @"Indent spacer values must be greater than zero. Received %@", @(indentSpacer));
-        typeof(self) newChain = self.copyWithoutNextText;
+        __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.indentSpacer = indentSpacer;
         return newChain;
     };

--- a/Pod/Classes/BONText.h
+++ b/Pod/Classes/BONText.h
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSUInteger, BONFigureSpacing) {
 
 - (void)setFontName:(NSString *)fontName size:(CGFloat)fontSize;
 @property (copy, nonatomic, readonly) NSString *fontName;
-@property (assign, nonatomic, readonly) CGFloat fontSize;
+@property (nonatomic, readonly) CGFloat fontSize;
 
 @property (strong, nonatomic) UIFont *font;
 
@@ -42,15 +42,15 @@ typedef NS_ENUM(NSUInteger, BONFigureSpacing) {
 @property (strong, nonatomic) UIColor *backgroundColor;
 
 // adobeTracking and pointTracking are two interpretations of the same unit. They cannot both be set - if one is set to any value, the other is set to 0.
-@property (assign, nonatomic) NSInteger adobeTracking;
-@property (assign, nonatomic) CGFloat pointTracking;
+@property (nonatomic) NSInteger adobeTracking;
+@property (nonatomic) CGFloat pointTracking;
 
-@property (assign, nonatomic) CGFloat lineHeightMultiple;
+@property (nonatomic) CGFloat lineHeightMultiple;
 
-@property (assign, nonatomic) CGFloat baselineOffset;
+@property (nonatomic) CGFloat baselineOffset;
 
-@property (assign, nonatomic) BONFigureCase figureCase;
-@property (assign, nonatomic) BONFigureSpacing figureSpacing;
+@property (nonatomic) BONFigureCase figureCase;
+@property (nonatomic) BONFigureSpacing figureSpacing;
 
 // string and image are mutually exclusive: setting one will unset the other
 @property (copy, nonatomic) NSString *string;
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSUInteger, BONFigureSpacing) {
 /**
  *  Space, in points, to apply after a preceding image or string. A combination of @headIndent and tab stops is used to indent the whole leading edge of the paragram, except for the preceding image or string, by the same amount, so they line up vertically. Must be greater than 0.
  */
-@property (assign, nonatomic) CGFloat indentSpacer;
+@property (nonatomic) CGFloat indentSpacer;
 
 // Getting Values Out
 

--- a/Pod/Classes/BONText.h
+++ b/Pod/Classes/BONText.h
@@ -49,6 +49,11 @@ typedef NS_ENUM(NSUInteger, BONFigureSpacing) {
 
 @property (nonatomic) CGFloat baselineOffset;
 
+/**
+ *  Defaults to @c NSTextAlignmentNatural.
+ */
+@property (nonatomic) NSTextAlignment alignment;
+
 @property (nonatomic) BONFigureCase figureCase;
 @property (nonatomic) BONFigureSpacing figureSpacing;
 

--- a/Pod/Classes/BONText.m
+++ b/Pod/Classes/BONText.m
@@ -26,7 +26,7 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
 @interface BONText ()
 
 @property (copy, nonatomic, readwrite) NSString *fontName;
-@property (assign, nonatomic, readwrite) CGFloat fontSize;
+@property (nonatomic, readwrite) CGFloat fontSize;
 
 @end
 

--- a/Pod/Classes/BONText.m
+++ b/Pod/Classes/BONText.m
@@ -32,6 +32,16 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
 
 @implementation BONText
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.alignment = NSTextAlignmentNatural;
+    }
+
+    return self;
+}
+
 - (NSAttributedString *)attributedString
 {
     NSArray *attributedStrings = self.attributedStrings;
@@ -144,6 +154,14 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
 {
     NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
 
+    __block NSMutableParagraphStyle *paragraphStyle = nil;
+
+    void (^populateParagraphStyleIfNecessary)() = ^{
+        if (!paragraphStyle) {
+            paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+        }
+    };
+
     // Color
 
     if ( self.textColor ) {
@@ -252,15 +270,25 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
     // Line Height
 
     if ( self.lineHeightMultiple != 1.0f ) {
-        NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+        populateParagraphStyleIfNecessary();
         paragraphStyle.lineHeightMultiple = self.lineHeightMultiple;
-        attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     }
 
     // Baseline Offset
 
     if ( self.baselineOffset != 0.0f && !self.image ) {
         attributes[NSBaselineOffsetAttributeName] = @(self.baselineOffset);
+    }
+
+    // Text Alignment
+
+    if ( self.alignment != NSTextAlignmentNatural ) {
+        populateParagraphStyleIfNecessary();
+        paragraphStyle.alignment = self.alignment;
+    }
+
+    if (paragraphStyle) {
+        attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     }
 
     return attributes;
@@ -277,6 +305,7 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
     text.pointTracking = self.pointTracking;
     text.lineHeightMultiple = self.lineHeightMultiple;
     text.baselineOffset = self.baselineOffset;
+    text.alignment = self.alignment;
     text.figureCase = self.figureCase;
     text.figureSpacing = self.figureSpacing;
     text.string = self.string;

--- a/Pod/Classes/BONText.m
+++ b/Pod/Classes/BONText.m
@@ -252,7 +252,7 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
     // Line Height
 
     if ( self.lineHeightMultiple != 1.0f ) {
-        NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init]; \
+        NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
         paragraphStyle.lineHeightMultiple = self.lineHeightMultiple;
         attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ BonMot uses attributed strings to give you control over the following typographi
 - Tracking (in either UIKit Points or Adobe-friendly thousandths of an *em*)
 - Line Height Multiple
 - Baseline Offset
+- Text alignment
 - Figure Case (uppercase vs. lowercase numbers)
 - Figure Spacing (monospace vs. proportional numbers)
 - Inline Images with optional multi-line paragraph alignment


### PR DESCRIPTION
Taking the naïve approach here: text alignment is applied to the string just like any other attribute, but because of the way attributed strings work, it will have an effect only on the first character after a line break that it is applied to. This should handle most cases - we can revisit anything where it doesn’t work.