### PR TITLE
Add more paragraph style attributes

### DIFF
--- a/Example/Tests/BONTextAlignmentTestCase.m
+++ b/Example/Tests/BONTextAlignmentTestCase.m
@@ -117,4 +117,38 @@
     XCTAssertEqualWithAccuracy(testParagraphStyle.paragraphSpacingBefore, 7.89, kBONCGFloatEpsilon);
 }
 
+// Test behavior when using both `headIndent` and `indentSpacer`
+- (void)testHeadIndentWithIndentSpacer
+{
+    BONChain *chain = BONChain.new
+        .image([UIImage imageNamed:@"robot" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil])
+        .headIndent(1.23)
+        .indentSpacer(4.0);
+    [chain appendLink:chain.string(@"test")];
+
+    NSDictionary *testAttributes = chain.attributes;
+    NSParagraphStyle *testParagraphStyle = testAttributes[NSParagraphStyleAttributeName];
+    NSAttributedString *testAttributedString = chain.attributedString;
+
+    // The `indentSpacer` doesn't overwrite the `headIndent` value
+    XCTAssertEqualWithAccuracy(testParagraphStyle.headIndent, 1.23, kBONCGFloatEpsilon);
+
+    [testAttributedString enumerateAttributesInRange:NSMakeRange(0, [testAttributedString length]) options:0 usingBlock:
+     ^(NSDictionary<NSString *,id> * _Nonnull attrs, NSRange range, BOOL * _Nonnull stop) {
+         NSParagraphStyle *paragraphStyle = attrs[NSParagraphStyleAttributeName];
+         if (paragraphStyle != nil) {
+             NSString *substring = [testAttributedString.string substringWithRange:range];
+             NSLog(@"\"%@\": %@", substring, paragraphStyle);
+
+             // The `indentSpacer` does overwrite the `headIndent` value for the object replacement character and the inserted tab
+             if ([substring isEqualToString:BONSpecial.objectReplacementCharacter] || [substring isEqualToString:@"\t"]) {
+                 XCTAssertEqualWithAccuracy(paragraphStyle.headIndent, 40.0, kBONCGFloatEpsilon);
+             }
+             else {
+                 XCTAssertEqualWithAccuracy(paragraphStyle.headIndent, 1.23, kBONCGFloatEpsilon);
+             }
+         }
+     }];
+}
+
 @end

--- a/Example/Tests/BONTextAlignmentTestCase.m
+++ b/Example/Tests/BONTextAlignmentTestCase.m
@@ -65,16 +65,34 @@
     XCTAssertEqual(testParagraphStyle.alignment, NSTextAlignmentCenter);
 }
 
-// Test setting line height multiple, line spacing, and alignment, since they all affect the paragraph style
-- (void)testMixingAlignmentLineHeightMultipleAndLineSpacing
+// Test setting the various paragraph style attributes
+- (void)testParagraphStyle
 {
-    BONChain *chain = BONChain.new.string(@"E pluribus unum").alignment(NSTextAlignmentCenter).lineHeightMultiple(3.14).lineSpacing(2.72);
+    BONChain *chain = BONChain.new
+        .string(@"E pluribus unum")
+        .alignment(NSTextAlignmentCenter)
+        .firstLineHeadIndent(1.23)
+        .headIndent(2.34)
+        .tailIndent(3.45)
+        .lineHeightMultiple(3.14)
+        .maximumLineHeight(5.67)
+        .minimumLineHeight(4.56)
+        .lineSpacing(2.72)
+        .paragraphSpacing(6.78)
+        .paragraphSpacingBefore(7.89);
     NSAttributedString *string = chain.attributedString;
 
     NSMutableParagraphStyle *controlParagraphStyle = [[NSMutableParagraphStyle alloc] init];
     controlParagraphStyle.alignment = NSTextAlignmentCenter;
+    controlParagraphStyle.firstLineHeadIndent = 1.23;
+    controlParagraphStyle.headIndent = 2.34;
+    controlParagraphStyle.tailIndent = 3.45;
     controlParagraphStyle.lineHeightMultiple = 3.14;
+    controlParagraphStyle.maximumLineHeight = 5.67;
+    controlParagraphStyle.minimumLineHeight = 4.56;
     controlParagraphStyle.lineSpacing = 2.72;
+    controlParagraphStyle.paragraphSpacing = 6.78;
+    controlParagraphStyle.paragraphSpacingBefore = 7.89;
 
     NSDictionary *controlAttributes = @{
         BONValueFromRange(0, 15) : @{
@@ -88,8 +106,15 @@
     NSParagraphStyle *testParagraphStyle = testAttributes[NSParagraphStyleAttributeName];
     XCTAssertNotNil(testParagraphStyle);
     XCTAssertEqual(testParagraphStyle.alignment, NSTextAlignmentCenter);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.firstLineHeadIndent, 1.23, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.headIndent, 2.34, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.tailIndent, 3.45, kBONCGFloatEpsilon);
     XCTAssertEqualWithAccuracy(testParagraphStyle.lineHeightMultiple, 3.14, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.maximumLineHeight, 5.67, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.minimumLineHeight, 4.56, kBONCGFloatEpsilon);
     XCTAssertEqualWithAccuracy(testParagraphStyle.lineSpacing, 2.72, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.paragraphSpacing, 6.78, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.paragraphSpacingBefore, 7.89, kBONCGFloatEpsilon);
 }
 
 @end

--- a/Example/Tests/BONTextAlignmentTestCase.m
+++ b/Example/Tests/BONTextAlignmentTestCase.m
@@ -78,7 +78,7 @@
         .maximumLineHeight(5.67)
         .minimumLineHeight(4.56)
         .lineSpacing(2.72)
-        .paragraphSpacing(6.78)
+        .paragraphSpacingAfter(6.78)
         .paragraphSpacingBefore(7.89);
     NSAttributedString *string = chain.attributedString;
 

--- a/Pod/Classes/BONChain.h
+++ b/Pod/Classes/BONChain.h
@@ -17,8 +17,15 @@ typedef BONChain * (^BONChainFont)(UIFont *font);
 typedef BONChain * (^BONChainColor)(UIColor *color);
 typedef BONChain * (^BONChainAdobeTracking)(NSInteger adobeTracking);
 typedef BONChain * (^BONChainPointTracking)(CGFloat pointTracking);
+typedef BONChain * (^BONChainFirstLineHeadIndent)(CGFloat firstLineHeadIndent);
+typedef BONChain * (^BONChainHeadIndent)(CGFloat headIndent);
+typedef BONChain * (^BONChainTailIndent)(CGFloat tailIndent);
 typedef BONChain * (^BONChainLineHeight)(CGFloat lineHeightMultiple);
+typedef BONChain * (^BONChainMaximumLineHeight)(CGFloat maximumLineHeight);
+typedef BONChain * (^BONChainMinimumLineHeight)(CGFloat minimumLineHeight);
 typedef BONChain * (^BONChainLineSpacing)(CGFloat lineSpacing);
+typedef BONChain * (^BONChainParagraphSpacing)(CGFloat paragraphSpacing);
+typedef BONChain * (^BONChainParagraphSpacingBefore)(CGFloat paragraphSpacingBefore);
 typedef BONChain * (^BONChainBaselineOffset)(CGFloat baselineOffset);
 typedef BONChain * (^BONChainAlignment)(NSTextAlignment alignment);
 typedef BONChain * (^BONChainFigureCase)(BONFigureCase figureCase);
@@ -50,8 +57,15 @@ typedef BONChain * (^BONChainStrikethroughColor)(UIColor *color);
 @property (copy, nonatomic, readonly) BONChainAdobeTracking adobeTracking;
 @property (copy, nonatomic, readonly) BONChainPointTracking pointTracking;
 
+@property (copy, nonatomic, readonly) BONChainFirstLineHeadIndent firstLineHeadIndent;
+@property (copy, nonatomic, readonly) BONChainHeadIndent headIndent;
+@property (copy, nonatomic, readonly) BONChainTailIndent tailIndent;
 @property (copy, nonatomic, readonly) BONChainLineHeight lineHeightMultiple;
+@property (copy, nonatomic, readonly) BONChainMaximumLineHeight maximumLineHeight;
+@property (copy, nonatomic, readonly) BONChainMinimumLineHeight minimumLineHeight;
 @property (copy, nonatomic, readonly) BONChainLineSpacing lineSpacing;
+@property (copy, nonatomic, readonly) BONChainParagraphSpacing paragraphSpacing;
+@property (copy, nonatomic, readonly) BONChainParagraphSpacingBefore paragraphSpacingBefore;
 
 @property (copy, nonatomic, readonly) BONChainBaselineOffset baselineOffset;
 

--- a/Pod/Classes/BONChain.h
+++ b/Pod/Classes/BONChain.h
@@ -24,7 +24,7 @@ typedef BONChain * (^BONChainLineHeight)(CGFloat lineHeightMultiple);
 typedef BONChain * (^BONChainMaximumLineHeight)(CGFloat maximumLineHeight);
 typedef BONChain * (^BONChainMinimumLineHeight)(CGFloat minimumLineHeight);
 typedef BONChain * (^BONChainLineSpacing)(CGFloat lineSpacing);
-typedef BONChain * (^BONChainParagraphSpacing)(CGFloat paragraphSpacing);
+typedef BONChain * (^BONChainParagraphSpacingAfter)(CGFloat paragraphSpacing);
 typedef BONChain * (^BONChainParagraphSpacingBefore)(CGFloat paragraphSpacingBefore);
 typedef BONChain * (^BONChainBaselineOffset)(CGFloat baselineOffset);
 typedef BONChain * (^BONChainAlignment)(NSTextAlignment alignment);
@@ -64,7 +64,7 @@ typedef BONChain * (^BONChainStrikethroughColor)(UIColor *color);
 @property (copy, nonatomic, readonly) BONChainMaximumLineHeight maximumLineHeight;
 @property (copy, nonatomic, readonly) BONChainMinimumLineHeight minimumLineHeight;
 @property (copy, nonatomic, readonly) BONChainLineSpacing lineSpacing;
-@property (copy, nonatomic, readonly) BONChainParagraphSpacing paragraphSpacingAfter;
+@property (copy, nonatomic, readonly) BONChainParagraphSpacingAfter paragraphSpacingAfter;
 @property (copy, nonatomic, readonly) BONChainParagraphSpacingBefore paragraphSpacingBefore;
 
 @property (copy, nonatomic, readonly) BONChainBaselineOffset baselineOffset;

--- a/Pod/Classes/BONChain.h
+++ b/Pod/Classes/BONChain.h
@@ -64,7 +64,7 @@ typedef BONChain * (^BONChainStrikethroughColor)(UIColor *color);
 @property (copy, nonatomic, readonly) BONChainMaximumLineHeight maximumLineHeight;
 @property (copy, nonatomic, readonly) BONChainMinimumLineHeight minimumLineHeight;
 @property (copy, nonatomic, readonly) BONChainLineSpacing lineSpacing;
-@property (copy, nonatomic, readonly) BONChainParagraphSpacing paragraphSpacing;
+@property (copy, nonatomic, readonly) BONChainParagraphSpacing paragraphSpacingAfter;
 @property (copy, nonatomic, readonly) BONChainParagraphSpacingBefore paragraphSpacingBefore;
 
 @property (copy, nonatomic, readonly) BONChainBaselineOffset baselineOffset;

--- a/Pod/Classes/BONChain.m
+++ b/Pod/Classes/BONChain.m
@@ -124,35 +124,35 @@
 
 - (BONChainFirstLineHeadIndent)firstLineHeadIndent
 {
-	BONChainFirstLineHeadIndent firstLineHeadIndentBlock = ^(CGFloat firstLineHeadIndent) {
-		__typeof(self) newChain = self.copyWithoutNextText;
-		newChain.text.firstLineHeadIndent = firstLineHeadIndent;
-		return newChain;
-	};
-	
-	return [firstLineHeadIndentBlock copy];
+    BONChainFirstLineHeadIndent firstLineHeadIndentBlock = ^(CGFloat firstLineHeadIndent) {
+        __typeof(self) newChain = self.copyWithoutNextText;
+        newChain.text.firstLineHeadIndent = firstLineHeadIndent;
+        return newChain;
+    };
+    
+    return [firstLineHeadIndentBlock copy];
 }
 
 - (BONChainHeadIndent)headIndent
 {
-	BONChainHeadIndent headIndentBlock = ^(CGFloat headIndent) {
-		__typeof(self) newChain = self.copyWithoutNextText;
-		newChain.text.headIndent = headIndent;
-		return newChain;
-	};
-	
-	return [headIndentBlock copy];
+    BONChainHeadIndent headIndentBlock = ^(CGFloat headIndent) {
+        __typeof(self) newChain = self.copyWithoutNextText;
+        newChain.text.headIndent = headIndent;
+        return newChain;
+    };
+    
+    return [headIndentBlock copy];
 }
 
 - (BONChainTailIndent)tailIndent
 {
-	BONChainTailIndent tailIndentBlock = ^(CGFloat tailIndent) {
-		__typeof(self) newChain = self.copyWithoutNextText;
-		newChain.text.tailIndent = tailIndent;
-		return newChain;
-	};
-	
-	return [tailIndentBlock copy];
+    BONChainTailIndent tailIndentBlock = ^(CGFloat tailIndent) {
+        __typeof(self) newChain = self.copyWithoutNextText;
+        newChain.text.tailIndent = tailIndent;
+        return newChain;
+    };
+    
+    return [tailIndentBlock copy];
 }
 
 - (BONChainLineHeight)lineHeightMultiple
@@ -168,24 +168,24 @@
 
 - (BONChainMaximumLineHeight)maximumLineHeight
 {
-	BONChainMaximumLineHeight maximumLineHeightBlock = ^(CGFloat maximumLineHeight) {
-		__typeof(self) newChain = self.copyWithoutNextText;
-		newChain.text.maximumLineHeight = maximumLineHeight;
-		return newChain;
-	};
-	
-	return [maximumLineHeightBlock copy];
+    BONChainMaximumLineHeight maximumLineHeightBlock = ^(CGFloat maximumLineHeight) {
+        __typeof(self) newChain = self.copyWithoutNextText;
+        newChain.text.maximumLineHeight = maximumLineHeight;
+        return newChain;
+    };
+    
+    return [maximumLineHeightBlock copy];
 }
 
 - (BONChainMinimumLineHeight)minimumLineHeight
 {
-	BONChainMinimumLineHeight minimumLineHeightBlock = ^(CGFloat minimumLineHeight) {
-		__typeof(self) newChain = self.copyWithoutNextText;
-		newChain.text.minimumLineHeight = minimumLineHeight;
-		return newChain;
-	};
-	
-	return [minimumLineHeightBlock copy];
+    BONChainMinimumLineHeight minimumLineHeightBlock = ^(CGFloat minimumLineHeight) {
+        __typeof(self) newChain = self.copyWithoutNextText;
+        newChain.text.minimumLineHeight = minimumLineHeight;
+        return newChain;
+    };
+    
+    return [minimumLineHeightBlock copy];
 }
 
 - (BONChainLineSpacing)lineSpacing
@@ -201,24 +201,24 @@
 
 - (BONChainParagraphSpacing)paragraphSpacing
 {
-	BONChainParagraphSpacing paragraphSpacingBlock = ^(CGFloat paragraphSpacing) {
-		__typeof(self) newChain = self.copyWithoutNextText;
-		newChain.text.paragraphSpacing = paragraphSpacing;
-		return newChain;
-	};
-	
-	return [paragraphSpacingBlock copy];
+    BONChainParagraphSpacing paragraphSpacingBlock = ^(CGFloat paragraphSpacing) {
+        __typeof(self) newChain = self.copyWithoutNextText;
+        newChain.text.paragraphSpacing = paragraphSpacing;
+        return newChain;
+    };
+    
+    return [paragraphSpacingBlock copy];
 }
 
 - (BONChainParagraphSpacingBefore)paragraphSpacingBefore
 {
-	BONChainParagraphSpacingBefore paragraphSpacingBeforeBlock = ^(CGFloat paragraphSpacingBefore) {
-		__typeof(self) newChain = self.copyWithoutNextText;
-		newChain.text.paragraphSpacingBefore = paragraphSpacingBefore;
-		return newChain;
-	};
-	
-	return [paragraphSpacingBeforeBlock copy];
+    BONChainParagraphSpacingBefore paragraphSpacingBeforeBlock = ^(CGFloat paragraphSpacingBefore) {
+        __typeof(self) newChain = self.copyWithoutNextText;
+        newChain.text.paragraphSpacingBefore = paragraphSpacingBefore;
+        return newChain;
+    };
+    
+    return [paragraphSpacingBeforeBlock copy];
 }
 
 - (BONChainBaselineOffset)baselineOffset

--- a/Pod/Classes/BONChain.m
+++ b/Pod/Classes/BONChain.m
@@ -199,15 +199,15 @@
     return [lineSpacingBlock copy];
 }
 
-- (BONChainParagraphSpacing)paragraphSpacing
+- (BONChainParagraphSpacing)paragraphSpacingAfter
 {
-    BONChainParagraphSpacing paragraphSpacingBlock = ^(CGFloat paragraphSpacing) {
+    BONChainParagraphSpacing paragraphSpacingAfterBlock = ^(CGFloat paragraphSpacing) {
         __typeof(self) newChain = self.copyWithoutNextText;
-        newChain.text.paragraphSpacing = paragraphSpacing;
+        newChain.text.paragraphSpacingAfter = paragraphSpacing;
         return newChain;
     };
     
-    return [paragraphSpacingBlock copy];
+    return [paragraphSpacingAfterBlock copy];
 }
 
 - (BONChainParagraphSpacingBefore)paragraphSpacingBefore

--- a/Pod/Classes/BONChain.m
+++ b/Pod/Classes/BONChain.m
@@ -199,9 +199,9 @@
     return [lineSpacingBlock copy];
 }
 
-- (BONChainParagraphSpacing)paragraphSpacingAfter
+- (BONChainParagraphSpacingAfter)paragraphSpacingAfter
 {
-    BONChainParagraphSpacing paragraphSpacingAfterBlock = ^(CGFloat paragraphSpacing) {
+    BONChainParagraphSpacingAfter paragraphSpacingAfterBlock = ^(CGFloat paragraphSpacing) {
         __typeof(self) newChain = self.copyWithoutNextText;
         newChain.text.paragraphSpacingAfter = paragraphSpacing;
         return newChain;

--- a/Pod/Classes/BONChain.m
+++ b/Pod/Classes/BONChain.m
@@ -122,6 +122,39 @@
     return [pointTrackingBlock copy];
 }
 
+- (BONChainFirstLineHeadIndent)firstLineHeadIndent
+{
+	BONChainFirstLineHeadIndent firstLineHeadIndentBlock = ^(CGFloat firstLineHeadIndent) {
+		__typeof(self) newChain = self.copyWithoutNextText;
+		newChain.text.firstLineHeadIndent = firstLineHeadIndent;
+		return newChain;
+	};
+	
+	return [firstLineHeadIndentBlock copy];
+}
+
+- (BONChainHeadIndent)headIndent
+{
+	BONChainHeadIndent headIndentBlock = ^(CGFloat headIndent) {
+		__typeof(self) newChain = self.copyWithoutNextText;
+		newChain.text.headIndent = headIndent;
+		return newChain;
+	};
+	
+	return [headIndentBlock copy];
+}
+
+- (BONChainTailIndent)tailIndent
+{
+	BONChainTailIndent tailIndentBlock = ^(CGFloat tailIndent) {
+		__typeof(self) newChain = self.copyWithoutNextText;
+		newChain.text.tailIndent = tailIndent;
+		return newChain;
+	};
+	
+	return [tailIndentBlock copy];
+}
+
 - (BONChainLineHeight)lineHeightMultiple
 {
     BONChainLineHeight lineHeightMultipleBlock = ^(CGFloat lineHeightMultiple) {
@@ -133,6 +166,28 @@
     return [lineHeightMultipleBlock copy];
 }
 
+- (BONChainMaximumLineHeight)maximumLineHeight
+{
+	BONChainMaximumLineHeight maximumLineHeightBlock = ^(CGFloat maximumLineHeight) {
+		__typeof(self) newChain = self.copyWithoutNextText;
+		newChain.text.maximumLineHeight = maximumLineHeight;
+		return newChain;
+	};
+	
+	return [maximumLineHeightBlock copy];
+}
+
+- (BONChainMinimumLineHeight)minimumLineHeight
+{
+	BONChainMinimumLineHeight minimumLineHeightBlock = ^(CGFloat minimumLineHeight) {
+		__typeof(self) newChain = self.copyWithoutNextText;
+		newChain.text.minimumLineHeight = minimumLineHeight;
+		return newChain;
+	};
+	
+	return [minimumLineHeightBlock copy];
+}
+
 - (BONChainLineSpacing)lineSpacing
 {
     BONChainLineSpacing lineSpacingBlock = ^(CGFloat lineSpacing) {
@@ -142,6 +197,28 @@
     };
 
     return [lineSpacingBlock copy];
+}
+
+- (BONChainParagraphSpacing)paragraphSpacing
+{
+	BONChainParagraphSpacing paragraphSpacingBlock = ^(CGFloat paragraphSpacing) {
+		__typeof(self) newChain = self.copyWithoutNextText;
+		newChain.text.paragraphSpacing = paragraphSpacing;
+		return newChain;
+	};
+	
+	return [paragraphSpacingBlock copy];
+}
+
+- (BONChainParagraphSpacingBefore)paragraphSpacingBefore
+{
+	BONChainParagraphSpacingBefore paragraphSpacingBeforeBlock = ^(CGFloat paragraphSpacingBefore) {
+		__typeof(self) newChain = self.copyWithoutNextText;
+		newChain.text.paragraphSpacingBefore = paragraphSpacingBefore;
+		return newChain;
+	};
+	
+	return [paragraphSpacingBeforeBlock copy];
 }
 
 - (BONChainBaselineOffset)baselineOffset

--- a/Pod/Classes/BONText.h
+++ b/Pod/Classes/BONText.h
@@ -45,8 +45,15 @@ typedef NS_ENUM(NSUInteger, BONFigureSpacing) {
 @property (nonatomic) NSInteger adobeTracking;
 @property (nonatomic) CGFloat pointTracking;
 
+@property (nonatomic) CGFloat firstLineHeadIndent;
+@property (nonatomic) CGFloat headIndent;
+@property (nonatomic) CGFloat tailIndent;
 @property (nonatomic) CGFloat lineHeightMultiple;
+@property (nonatomic) CGFloat maximumLineHeight;
+@property (nonatomic) CGFloat minimumLineHeight;
 @property (nonatomic) CGFloat lineSpacing;
+@property (nonatomic) CGFloat paragraphSpacing;
+@property (nonatomic) CGFloat paragraphSpacingBefore;
 
 @property (nonatomic) CGFloat baselineOffset;
 

--- a/Pod/Classes/BONText.h
+++ b/Pod/Classes/BONText.h
@@ -52,7 +52,7 @@ typedef NS_ENUM(NSUInteger, BONFigureSpacing) {
 @property (nonatomic) CGFloat maximumLineHeight;
 @property (nonatomic) CGFloat minimumLineHeight;
 @property (nonatomic) CGFloat lineSpacing;
-@property (nonatomic) CGFloat paragraphSpacing;
+@property (nonatomic) CGFloat paragraphSpacingAfter;
 @property (nonatomic) CGFloat paragraphSpacingBefore;
 
 @property (nonatomic) CGFloat baselineOffset;

--- a/Pod/Classes/BONText.h
+++ b/Pod/Classes/BONText.h
@@ -71,6 +71,8 @@ typedef NS_ENUM(NSUInteger, BONFigureSpacing) {
 
 /**
  *  Space, in points, to apply after a preceding image or string. A combination of @c headIndent and tab stops is used to indent the whole leading edge of the paragram, except for the preceding image or string, by the same amount, so they line up vertically. Must be greater than 0.
+ *
+ *  NOTE: Using this property will overwrite the headIndent property for the paragraph.
  */
 @property (nonatomic) CGFloat indentSpacer;
 

--- a/Pod/Classes/BONText.m
+++ b/Pod/Classes/BONText.m
@@ -263,6 +263,27 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
         attributes[NSKernAttributeName] = @(trackingInPoints);
     }
 
+    // First Line Head Indent
+    
+    if (self.firstLineHeadIndent != 0.0f) {
+        populateParagraphStyleIfNecessary();
+        paragraphStyle.firstLineHeadIndent = self.firstLineHeadIndent;
+    }
+
+    // Head Indent
+    
+    if (self.headIndent != 0.0f) {
+        populateParagraphStyleIfNecessary();
+        paragraphStyle.headIndent = self.headIndent;
+    }
+
+    // Head Indent
+    
+    if (self.tailIndent != 0.0f) {
+        populateParagraphStyleIfNecessary();
+        paragraphStyle.tailIndent = self.tailIndent;
+    }
+
     // Line Height
 
     if (self.lineHeightMultiple != 1.0f) {
@@ -270,11 +291,39 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
         paragraphStyle.lineHeightMultiple = self.lineHeightMultiple;
     }
 
+    // Maximum Line Height
+    
+    if (self.maximumLineHeight != 1.0f) {
+        populateParagraphStyleIfNecessary();
+        paragraphStyle.maximumLineHeight = self.maximumLineHeight;
+    }
+
+    // Minimum Line Height
+    
+    if (self.minimumLineHeight != 1.0f) {
+        populateParagraphStyleIfNecessary();
+        paragraphStyle.minimumLineHeight = self.minimumLineHeight;
+    }
+
     // Line Spacing
 
     if (self.lineSpacing != 0.0f) {
         populateParagraphStyleIfNecessary();
         paragraphStyle.lineSpacing = self.lineSpacing;
+    }
+
+    // Paragraph Spacing
+    
+    if (self.paragraphSpacing != 0.0f) {
+        populateParagraphStyleIfNecessary();
+        paragraphStyle.paragraphSpacing = self.paragraphSpacing;
+    }
+
+    // Paragraph Spacing Before
+    
+    if (self.paragraphSpacingBefore != 0.0f) {
+        populateParagraphStyleIfNecessary();
+        paragraphStyle.paragraphSpacingBefore = self.paragraphSpacingBefore;
     }
 
     // Baseline Offset
@@ -326,8 +375,15 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
     text.backgroundColor = self.backgroundColor;
     text.adobeTracking = self.adobeTracking;
     text.pointTracking = self.pointTracking;
+    text.firstLineHeadIndent = self.firstLineHeadIndent;
+    text.headIndent = self.headIndent;
+    text.tailIndent = self.tailIndent;
     text.lineHeightMultiple = self.lineHeightMultiple;
+    text.maximumLineHeight = self.maximumLineHeight;
+    text.minimumLineHeight = self.minimumLineHeight;
     text.lineSpacing = self.lineSpacing;
+    text.paragraphSpacing = self.paragraphSpacing;
+    text.paragraphSpacingBefore = self.paragraphSpacingBefore;
     text.baselineOffset = self.baselineOffset;
     text.alignment = self.alignment;
     text.figureCase = self.figureCase;

--- a/Pod/Classes/BONText.m
+++ b/Pod/Classes/BONText.m
@@ -314,9 +314,9 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
 
     // Paragraph Spacing
     
-    if (self.paragraphSpacing != 0.0f) {
+    if (self.paragraphSpacingAfter != 0.0f) {
         populateParagraphStyleIfNecessary();
-        paragraphStyle.paragraphSpacing = self.paragraphSpacing;
+        paragraphStyle.paragraphSpacing = self.paragraphSpacingAfter;
     }
 
     // Paragraph Spacing Before
@@ -382,7 +382,7 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
     text.maximumLineHeight = self.maximumLineHeight;
     text.minimumLineHeight = self.minimumLineHeight;
     text.lineSpacing = self.lineSpacing;
-    text.paragraphSpacing = self.paragraphSpacing;
+    text.paragraphSpacingAfter = self.paragraphSpacingAfter;
     text.paragraphSpacingBefore = self.paragraphSpacingBefore;
     text.baselineOffset = self.baselineOffset;
     text.alignment = self.alignment;

--- a/README.md
+++ b/README.md
@@ -34,8 +34,15 @@ BonMot uses attributed strings to give you control over the following typographi
 - Font
 - Text color
 - Tracking (in either UIKit Points or Adobe-friendly thousandths of an *em*)
+- First line head indent
+- Head indent
+- Tail indent
 - Line height multiple
+- Maximum line height
+- Minimum line height
 - Line spacing
+- Paragraph spacing
+- Paragraph spacing before
 - Baseline offset
 - Text alignment
 - Underlining and strikethrough


### PR DESCRIPTION
This commit adds several more attributes from the NSParagraphStyle properties, including the firstLineHeadIndent, headIndent, tailIndent, maximumLineHeight, minimumLineHeight, paragraphSpacing, and paragraphSpacingBefore properties. Unit tests have also been added to test these new properties.