### PR TITLE
Fix Xcode 7.3 warnings about float/double precision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@
 
 language: objective-c
 osx_image: xcode7.2
-# cache: cocoapods
-# podfile: Example/Podfile
-# before_install:
-# - gem install cocoapods # Since Travis is not always on latest version
-# - pod install --project-directory=Example
 install:
 - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 # * https://github.com/supermarin/xcpretty#usage
 
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode7.3
 install:
 - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 script:

--- a/Example/BonMot/Cells/AbstractCell.m
+++ b/Example/BonMot/Cells/AbstractCell.m
@@ -28,10 +28,10 @@
 
 + (UIColor *)raizlabsRed
 {
-    return [UIColor colorWithRed:0.927f
-                           green:0.352f
-                            blue:0.303f
-                           alpha:1.0f];
+    return [UIColor colorWithRed:0.927
+                           green:0.352
+                            blue:0.303
+                           alpha:1.0];
 }
 
 @end

--- a/Example/BonMot/Cells/BaselineCapHeightCell.m
+++ b/Example/BonMot/Cells/BaselineCapHeightCell.m
@@ -32,7 +32,7 @@ static NSString *const kFontNameEBGaramond = @"EBGaramond12-Regular";
 {
     [super awakeFromNib];
 
-    NSAttributedString *numberString = BONChain.new.fontNameAndSize(kFontNameEBGaramond, 100.0f).figureCase(BONFigureCaseOldstyle).string(@"167").attributedString;
+    NSAttributedString *numberString = BONChain.new.fontNameAndSize(kFontNameEBGaramond, 100.0).figureCase(BONFigureCaseOldstyle).string(@"167").attributedString;
 
     for (UILabel *label in self.capHeightNumberLabels) {
         label.attributedText = numberString;
@@ -43,8 +43,8 @@ static NSString *const kFontNameEBGaramond = @"EBGaramond12-Regular";
                                  relatedBy:NSLayoutRelationEqual
                                     toItem:self.capHeightBaselineHairline
                                  attribute:NSLayoutAttributeBottom
-                                multiplier:1.0f
-                                  constant:0.0f]
+                                multiplier:1.0
+                                  constant:0.0]
         .active = YES;
 
     [NSLayoutConstraint constraintWithItem:self.numberXHeightLabel
@@ -52,8 +52,8 @@ static NSString *const kFontNameEBGaramond = @"EBGaramond12-Regular";
                                  relatedBy:NSLayoutRelationEqual
                                     toItem:self.xHeightBaselineHairline
                                  attribute:NSLayoutAttributeBottom
-                                multiplier:1.0f
-                                  constant:0.0f]
+                                multiplier:1.0
+                                  constant:0.0]
         .active = YES;
 }
 

--- a/Example/BonMot/Cells/BaselineOffsetCell.m
+++ b/Example/BonMot/Cells/BaselineOffsetCell.m
@@ -30,7 +30,7 @@
     NSMutableArray *wave = [NSMutableArray array];
 
     for (NSUInteger i = 0; i < 50; i++) {
-        CGFloat offset = 15.0f * sin((i / 20.0f) * 7.0f * M_PI);
+        CGFloat offset = 15.0 * sin((i / 20.0) * 7.0 * M_PI);
         [wave addObject:baseChain.baselineOffset(offset).text];
     };
 

--- a/Example/BonMot/Cells/ColorCell.m
+++ b/Example/BonMot/Cells/ColorCell.m
@@ -37,11 +37,11 @@
         @"\nMaria Sharapova ",
     ];
 
-    BONChain *baseLineHeight = BONChain.new.lineHeightMultiple(1.2f);
+    BONChain *baseLineHeight = BONChain.new.lineHeightMultiple(1.2);
 
-    BONChain *grayFont = baseLineHeight.fontNameAndSize(@"GillSans-Light", 20.0f).textColor([UIColor darkGrayColor]);
+    BONChain *grayFont = baseLineHeight.fontNameAndSize(@"GillSans-Light", 20.0).textColor([UIColor darkGrayColor]);
 
-    BONChain *fancyFont = baseLineHeight.fontNameAndSize(@"SuperClarendon-Black", 20.0f);
+    BONChain *fancyFont = baseLineHeight.fontNameAndSize(@"SuperClarendon-Black", 20.0);
 
     BONChain *blackBackground = fancyFont.textColor([UIColor whiteColor]).backgroundColor([UIColor blackColor]);
 
@@ -71,7 +71,7 @@
 
     UIImage *tennisRacketImage = [UIImage imageNamed:@"Tennis Racket"];
     UIImage *tinted = [tennisRacketImage bon_tintedImageWithColor:[self.class raizlabsRed]];
-    BONChain *tennisRacket = BONChain.new.image(tinted).baselineOffset(-4.0f);
+    BONChain *tennisRacket = BONChain.new.image(tinted).baselineOffset(-4.0);
 
     [textsWithStrings addObject:tennisRacket.text];
 

--- a/Example/BonMot/Cells/ConcatenationCell.m
+++ b/Example/BonMot/Cells/ConcatenationCell.m
@@ -8,7 +8,7 @@
 
 #import "ConcatenationCell.h"
 
-static const CGFloat kColorAlpha = 0.3f;
+static const CGFloat kColorAlpha = 0.3;
 static const NSInteger kTracking = 200;
 
 @interface ConcatenationCell ()

--- a/Example/BonMot/Cells/FigureStyleCell.m
+++ b/Example/BonMot/Cells/FigureStyleCell.m
@@ -35,7 +35,7 @@ static NSString *const kFontNameEBGaramond = @"EBGaramond12-Regular";
     NSString *tabularLiningString = self.tabularLiningLabel.text;
     NSString *tabularOldstyleString = self.tabularOldstyleLabel.text;
 
-    UIFont *ebGaramond = [UIFont fontWithName:kFontNameEBGaramond size:24.0f];
+    UIFont *ebGaramond = [UIFont fontWithName:kFontNameEBGaramond size:24.0];
 
     BONChain *commonFont = BONChain.new.font(ebGaramond);
 

--- a/Example/BonMot/Cells/IndentationCell.m
+++ b/Example/BonMot/Cells/IndentationCell.m
@@ -30,8 +30,8 @@
     NSString *quote = @"“It’s OK to ask for help. When doing a final exam, all the work must be yours, but in engineering, the point is to get the job done, and people are happy to help. Corollaries: You should be generous with credit, and you should be happy to help others.”";
     NSString *attribution = [NSString stringWithFormat:@"%@%@Radia Perlman", BONSpecial.lineSeparator, BONSpecial.emDash];
     UIImage *image = [UIImage imageNamed:@"robot"];
-    BONChain *firstBaseTextChain = BONChain.new.fontNameAndSize(@"AvenirNextCondensed-Medium", 18.0f);
-    BONChain *imageChain = firstBaseTextChain.image(image).indentSpacer(4.0f).baselineOffset(-6.0f);
+    BONChain *firstBaseTextChain = BONChain.new.fontNameAndSize(@"AvenirNextCondensed-Medium", 18.0);
+    BONChain *imageChain = firstBaseTextChain.image(image).indentSpacer(4.0).baselineOffset(-6.0);
 
     [imageChain appendLink:firstBaseTextChain.string(quote)];
     [imageChain appendLink:firstBaseTextChain.string(attribution)];
@@ -42,8 +42,8 @@
 
     // Second Quote
     NSString *secondQuote = @"You can also use strings (including emoji) for bullets as well, and they will still properly indent the appended text by the right amount.";
-    BONChain *secondBaseTextChain = BONChain.new.fontNameAndSize(@"AvenirNextCondensed-Regular", 18.0f);
-    BONChain *secondChain = secondBaseTextChain.string(@"🍑 →").indentSpacer(4.0f).textColor([UIColor orangeColor]);
+    BONChain *secondBaseTextChain = BONChain.new.fontNameAndSize(@"AvenirNextCondensed-Regular", 18.0);
+    BONChain *secondChain = secondBaseTextChain.string(@"🍑 →").indentSpacer(4.0).textColor([UIColor orangeColor]);
     [secondChain appendLink:secondBaseTextChain.string(secondQuote).textColor([UIColor darkGrayColor])];
 
     NSAttributedString *textAttributedString = secondChain.attributedString;

--- a/Example/BonMot/Cells/InlineImagesCell.m
+++ b/Example/BonMot/Cells/InlineImagesCell.m
@@ -29,13 +29,13 @@
     UIImage *knot = [UIImage imageNamed:@"knot"];
     UIImage *oar = [UIImage imageNamed:@"oar"];
 
-    BONChain *imageBaselineChain = BONChain.new.baselineOffset(-8.0f);
+    BONChain *imageBaselineChain = BONChain.new.baselineOffset(-8.0);
 
     BONChain *beeChain = imageBaselineChain.image(bee);
     BONChain *knotChain = imageBaselineChain.image(knot);
     BONChain *oarChain = imageBaselineChain.image(oar);
 
-    BONChain *twoChain = BONChain.new.string(@"2").fontNameAndSize(@"HelveticaNeue-Bold", 24.0f);
+    BONChain *twoChain = BONChain.new.string(@"2").fontNameAndSize(@"HelveticaNeue-Bold", 24.0);
 
     BONChain *spaceChain = BONChain.new.string(@" ");
 

--- a/Example/BonMot/Cells/LineHeightCell.m
+++ b/Example/BonMot/Cells/LineHeightCell.m
@@ -26,7 +26,7 @@
     [super awakeFromNib];
 
     NSString *quote = @"I used to love correcting people’s grammar until I realized what I loved more was having friends.\n—Mara Wilson";
-    NSAttributedString *attributedString = BONChain.new.fontNameAndSize(@"AmericanTypewriter", 17.0f).lineHeightMultiple(1.8f).string(quote).attributedString;
+    NSAttributedString *attributedString = BONChain.new.fontNameAndSize(@"AmericanTypewriter", 17.0).lineHeightMultiple(1.8).string(quote).attributedString;
 
     self.label.attributedText = attributedString;
 

--- a/Example/BonMot/Cells/ProgrammaticBaselineCapHeightCell.m
+++ b/Example/BonMot/Cells/ProgrammaticBaselineCapHeightCell.m
@@ -39,7 +39,7 @@ static NSString *const kFontNameEBGaramond = @"EBGaramond12-Regular";
 {
     [super awakeFromNib];
 
-    NSAttributedString *numberString = BONChain.new.fontNameAndSize(kFontNameEBGaramond, 100.0f).figureCase(BONFigureCaseOldstyle).string(@"167").attributedString;
+    NSAttributedString *numberString = BONChain.new.fontNameAndSize(kFontNameEBGaramond, 100.0).figureCase(BONFigureCaseOldstyle).string(@"167").attributedString;
 
     for (UILabel *label in self.capHeightNumberLabels) {
         label.attributedText = numberString;
@@ -80,8 +80,8 @@ static NSString *const kFontNameEBGaramond = @"EBGaramond12-Regular";
                                  relatedBy:NSLayoutRelationEqual
                                     toItem:self.capHeightBaselineHairline
                                  attribute:NSLayoutAttributeBottom
-                                multiplier:1.0f
-                                  constant:0.0f]
+                                multiplier:1.0
+                                  constant:0.0]
         .active = YES;
 
     [NSLayoutConstraint constraintWithItem:self.numberXHeightLabel
@@ -89,8 +89,8 @@ static NSString *const kFontNameEBGaramond = @"EBGaramond12-Regular";
                                  relatedBy:NSLayoutRelationEqual
                                     toItem:self.xHeightBaselineHairline
                                  attribute:NSLayoutAttributeBottom
-                                multiplier:1.0f
-                                  constant:0.0f]
+                                multiplier:1.0
+                                  constant:0.0]
         .active = YES;
 }
 

--- a/Example/BonMot/Cells/SpecialCharactersCell.m
+++ b/Example/BonMot/Cells/SpecialCharactersCell.m
@@ -43,7 +43,7 @@
     NSAssert(imageNames.count == words.count, @"We must have the same number of words as images");
 
     BONChain *baseTextChain = BONChain.new.textColor([UIColor darkGrayColor]);
-    BONChain *baseImageChain = BONChain.new.baselineOffset(-10.0f);
+    BONChain *baseImageChain = BONChain.new.baselineOffset(-10.0);
     NSMutableArray *chunks = [NSMutableArray array];
 
     for (NSUInteger theIndex = 0; theIndex < imageNames.count; theIndex++) {

--- a/Example/BonMot/Cells/TrackingCell.m
+++ b/Example/BonMot/Cells/TrackingCell.m
@@ -26,7 +26,7 @@
     [super awakeFromNib];
 
     NSString *quote = @"Adults are always asking kids what they want to be when they grow up because they are looking for ideas.\n—Paula Poundstone";
-    NSAttributedString *attributedString = BONChain.new.adobeTracking(300).fontNameAndSize(@"Avenir-Book", 18.0f).string(quote).attributedString;
+    NSAttributedString *attributedString = BONChain.new.adobeTracking(300).fontNameAndSize(@"Avenir-Book", 18.0).string(quote).attributedString;
 
     self.label.attributedText = attributedString;
 

--- a/Example/BonMot/DashedHairlineView.m
+++ b/Example/BonMot/DashedHairlineView.m
@@ -19,8 +19,8 @@
     CGContextSetLineDash(ctx, 0, dash, 2);
 
     CGContextSetLineWidth(ctx, CGRectGetHeight(self.bounds));
-    CGContextMoveToPoint(ctx, 0.0, CGRectGetHeight(self.bounds) / 2.0f);
-    CGContextAddLineToPoint(ctx, CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds) / 2.0f);
+    CGContextMoveToPoint(ctx, 0.0, CGRectGetHeight(self.bounds) / 2);
+    CGContextAddLineToPoint(ctx, CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds) / 2);
     CGContextSetStrokeColorWithColor(ctx, RAIZLABS_RED.CGColor);
     CGContextStrokePath(ctx);
 }

--- a/Example/BonMot/DashedHairlineView.m
+++ b/Example/BonMot/DashedHairlineView.m
@@ -8,18 +8,18 @@
 
 #import "DashedHairlineView.h"
 
-#define RAIZLABS_RED [UIColor colorWithRed:0.927f green:0.352f blue:0.303f alpha:1.0f]
+#define RAIZLABS_RED [UIColor colorWithRed:0.927 green:0.352 blue:0.303 alpha:1.0]
 
 @implementation DashedHairlineView
 
 - (void)drawRect:(CGRect)rect
 {
     CGContextRef ctx = UIGraphicsGetCurrentContext();
-    const CGFloat dash[2] = {5.0f, 5.0f}; // pattern 6 times “solid”, 5 times “empty”
+    const CGFloat dash[2] = {5.0, 5.0}; // pattern 6 times “solid”, 5 times “empty”
     CGContextSetLineDash(ctx, 0, dash, 2);
 
     CGContextSetLineWidth(ctx, CGRectGetHeight(self.bounds));
-    CGContextMoveToPoint(ctx, 0.0f, CGRectGetHeight(self.bounds) / 2.0f);
+    CGContextMoveToPoint(ctx, 0.0, CGRectGetHeight(self.bounds) / 2.0f);
     CGContextAddLineToPoint(ctx, CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds) / 2.0f);
     CGContextSetStrokeColorWithColor(ctx, RAIZLABS_RED.CGColor);
     CGContextStrokePath(ctx);

--- a/Example/BonMot/NSDictionary+BONEquality.h
+++ b/Example/BonMot/NSDictionary+BONEquality.h
@@ -12,8 +12,8 @@
 
 @import CoreGraphics.CGBase;
 
-OBJC_EXTERN const CGFloat kBONCGFloatEpsilon;
-OBJC_EXTERN BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2);
+OBJC_EXTERN const double kBONDoubleEpsilon;
+OBJC_EXTERN BOOL BONDoublesCloseEnough(double float1, double float2);
 
 @interface BONGenericDict (BONEquality)
 

--- a/Example/BonMot/NSDictionary+BONEquality.m
+++ b/Example/BonMot/NSDictionary+BONEquality.m
@@ -10,11 +10,11 @@
 
 @import CoreGraphics.CGBase;
 
-CGFloat const kBONCGFloatEpsilon = 0.0001;
+const double kBONDoubleEpsilon = 0.0001;
 
-BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
+BOOL BONDoublesCloseEnough(double float1, double float2)
 {
-    return fabs(float1 - float2) < kBONCGFloatEpsilon;
+    return fabs(float1 - float2) < kBONDoubleEpsilon;
 }
 
 static BOOL BONNumberIsFloaty(NSNumber *number)
@@ -45,9 +45,9 @@ static BOOL BONNumberIsFloaty(NSNumber *number)
                 if (![selfValue isEqual:otherValue]) {
                     if ([selfValue isKindOfClass:[NSNumber class]] && [otherValue isKindOfClass:[NSNumber class]]) {
                         if (BONNumberIsFloaty(selfValue) && BONNumberIsFloaty(otherValue)) {
-                            CGFloat selfFloat = [selfValue floatValue];
-                            CGFloat otherFloat = [otherValue floatValue];
-                            BOOL closeEnough = BONCGFloatsCloseEnough(selfFloat, otherFloat);
+                            double selfDouble = [selfValue doubleValue];
+                            double otherDouble = [otherValue doubleValue];
+                            BOOL closeEnough = BONDoublesCloseEnough(selfDouble, otherDouble);
                             if (!closeEnough) {
                                 equal = NO;
                                 break;

--- a/Example/BonMot/RootViewController.m
+++ b/Example/BonMot/RootViewController.m
@@ -34,7 +34,7 @@
     [super viewDidLoad];
 
     self.tableView.rowHeight = UITableViewAutomaticDimension;
-    self.tableView.estimatedRowHeight = 123.0f;
+    self.tableView.estimatedRowHeight = 123.0;
 
     self.cellClasses = @[
         [ColorCell class],

--- a/Example/Tests/BONChainableTestCase.m
+++ b/Example/Tests/BONChainableTestCase.m
@@ -147,8 +147,8 @@
 {
     UIImage *barnImage = [UIImage imageNamed:@"barn" inBundle:[NSBundle bundleForClass:[DummyAssetClass class]] compatibleWithTraitCollection:nil];
     XCTAssertNotNil(barnImage);
-    XCTAssertEqualWithAccuracy(barnImage.size.width, 36.0, kBONCGFloatEpsilon);
-    XCTAssertEqualWithAccuracy(barnImage.size.height, 36.0, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(barnImage.size.width, 36.0, kBONDoubleEpsilon);
+    XCTAssertEqualWithAccuracy(barnImage.size.height, 36.0, kBONDoubleEpsilon);
 
     BONChain *imageChain = BONChain.new.image(barnImage);
 

--- a/Example/Tests/BONDictionaryEqualityTestCase.m
+++ b/Example/Tests/BONDictionaryEqualityTestCase.m
@@ -17,7 +17,7 @@
 
 - (void)testReflexivity
 {
-    NSDictionary *theDict = @{ @"asdf" : @1.0f };
+    NSDictionary *theDict = @{ @"asdf" : @1.0 };
     XCTAssertTrue([theDict bon_isCloseEnoughEqualToDictionary:theDict]);
 
     NSDictionary *nilDict = nil;
@@ -26,12 +26,12 @@
 
 - (void)testUnambiguouslyWrong
 {
-    NSDictionary *dict1 = @{ @"asdf" : @1.0f };
+    NSDictionary *dict1 = @{ @"asdf" : @1.0 };
     NSDictionary *dict2 = @{ @"jkl;" : @"a string" };
     XCTAssertFalse([dict1 bon_isCloseEnoughEqualToDictionary:dict2]);
 
     NSDictionary *dict3 = @{
-        @"asdf" : @1.0f,
+        @"asdf" : @1.0,
         @"more keys" : @"just stuff",
     };
     XCTAssertFalse([dict1 bon_isCloseEnoughEqualToDictionary:dict3]);
@@ -42,7 +42,7 @@
 {
     NSString *key = @"key";
     NSString *otherKey = @"otherKey";
-    XCTAssertTrue([@{ key : @(1.0f / 3.0f) } bon_isCloseEnoughEqualToDictionary:@{ key : @(1.0 / 3.0) }]);
+    XCTAssertTrue([@{ key : @(1.0 / 3.0) } bon_isCloseEnoughEqualToDictionary:@{ key : @(1.0 / 3.0) }]);
     XCTAssertTrue([@{ key : @3.14000000001 } bon_isCloseEnoughEqualToDictionary:@{ key : @3.14000000002 }]);
 
     NSDictionary *dict1 = @{ key : @3.14000000001 };
@@ -55,9 +55,9 @@
 
 - (void)testMutableDictionary
 {
-    NSMutableDictionary *dict1 = [@{ @"asdf" : @1.0f } mutableCopy];
-    NSMutableDictionary *dict2 = [@{ @"asdf" : @1.0f } mutableCopy];
-    NSDictionary *dict3 = @{ @"asdf" : @1.0f };
+    NSMutableDictionary *dict1 = [@{ @"asdf" : @1.0 } mutableCopy];
+    NSMutableDictionary *dict2 = [@{ @"asdf" : @1.0 } mutableCopy];
+    NSDictionary *dict3 = @{ @"asdf" : @1.0 };
     XCTAssertTrue([dict1 bon_isCloseEnoughEqualToDictionary:dict2]);
     XCTAssertTrue([dict2 bon_isCloseEnoughEqualToDictionary:dict1]);
     XCTAssertTrue([dict2 bon_isCloseEnoughEqualToDictionary:dict3]);
@@ -68,9 +68,9 @@
 
 - (void)testBONAssertEqualDictionaries
 {
-    NSMutableDictionary *dict1 = [@{ @"asdf" : @1.000001f } mutableCopy];
-    NSMutableDictionary *dict2 = [@{ @"asdf" : @1.000002f } mutableCopy];
-    NSDictionary *dict3 = @{ @"asdf" : @1.000003f };
+    NSMutableDictionary *dict1 = [@{ @"asdf" : @1.000001 } mutableCopy];
+    NSMutableDictionary *dict2 = [@{ @"asdf" : @1.000002 } mutableCopy];
+    NSDictionary *dict3 = @{ @"asdf" : @1.000003 };
     BONAssertEqualDictionaries(dict1, dict2);
     BONAssertEqualDictionaries(dict2, dict1);
     BONAssertEqualDictionaries(dict2, dict3);
@@ -79,13 +79,13 @@
     BONAssertEqualDictionaries(dict3, dict1);
 }
 
-- (void)testBONCGFloatsCloseEnough
+- (void)testBONDoublesCloseEnough
 {
-    XCTAssertTrue(BONCGFloatsCloseEnough(0.0f, 0.0f));
-    XCTAssertTrue(BONCGFloatsCloseEnough(0.0f, 0.0000000001f));
-    XCTAssertTrue(BONCGFloatsCloseEnough((1.0f - 0.9f) - 0.1f, 0.0f));
-    XCTAssertTrue(BONCGFloatsCloseEnough((1.0 - 0.9) - 0.1, 0.0f));
-    XCTAssertFalse(BONCGFloatsCloseEnough(0.0f, 0.01f));
+    XCTAssertTrue(BONDoublesCloseEnough(0.0, 0.0));
+    XCTAssertTrue(BONDoublesCloseEnough(0.0, 0.0000000001));
+    XCTAssertTrue(BONDoublesCloseEnough((1.0 - 0.9) - 0.1, 0.0));
+    XCTAssertTrue(BONDoublesCloseEnough((1.0 - 0.9) - 0.1, 0.0));
+    XCTAssertFalse(BONDoublesCloseEnough(0.0, 0.01));
 }
 
 @end

--- a/Example/Tests/BONIndentSpacerTestCase.m
+++ b/Example/Tests/BONIndentSpacerTestCase.m
@@ -20,8 +20,8 @@
 {
     NSString *quote = [NSString stringWithFormat:@"“It’s OK to ask for help. When doing a final exam, all the work must be yours, but in engineering, the point is to get the job done, and people are happy to help. Corollaries: You should be generous with credit, and you should be happy to help others.”%@%@Radia Perlman.", BONSpecial.lineSeparator, BONSpecial.emDash];
     UIImage *image = [UIImage imageNamed:@"robot" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil];
-    BONChain *baseTextChain = BONChain.new.fontNameAndSize(@"AvenirNextCondensed-Medium", 18.0f);
-    BONChain *imageChain = baseTextChain.image(image).indentSpacer(4.0f).baselineOffset(-6.0f);
+    BONChain *baseTextChain = BONChain.new.fontNameAndSize(@"AvenirNextCondensed-Medium", 18.0);
+    BONChain *imageChain = baseTextChain.image(image).indentSpacer(4.0).baselineOffset(-6.0);
 
     [imageChain appendLink:baseTextChain.string(quote)];
 
@@ -34,8 +34,8 @@
 - (void)testIndentingWithText
 {
     NSString *secondQuote = @"You can also use strings (including emoji) for bullets as well, and they will still properly indent the appended text by the right amount.";
-    BONChain *baseTextChain = BONChain.new.fontNameAndSize(@"AvenirNextCondensed-Regular", 18.0f);
-    BONChain *secondChain = baseTextChain.string(@"🍑 →").indentSpacer(4.0f).textColor([UIColor orangeColor]);
+    BONChain *baseTextChain = BONChain.new.fontNameAndSize(@"AvenirNextCondensed-Regular", 18.0);
+    BONChain *secondChain = baseTextChain.string(@"🍑 →").indentSpacer(4.0).textColor([UIColor orangeColor]);
     [secondChain appendLink:baseTextChain.string(secondQuote).textColor([UIColor darkGrayColor])];
 
     NSAttributedString *attributedString = secondChain.attributedString;
@@ -48,9 +48,9 @@
     NSString *string1 = [NSString stringWithFormat:@"string1"];
     NSString *string2 = [NSString stringWithFormat:@"string2"];
     UIImage *image = [UIImage imageNamed:@"robot" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil];
-    BONChain *firstBaseTextChain = BONChain.new.fontNameAndSize(@"AvenirNextCondensed-Medium", 18.0f);
+    BONChain *firstBaseTextChain = BONChain.new.fontNameAndSize(@"AvenirNextCondensed-Medium", 18.0);
     BONChain *imageChain = firstBaseTextChain.copy;
-    [imageChain appendLink:firstBaseTextChain.image(image).indentSpacer(4.0f).baselineOffset(-6.0f)];
+    [imageChain appendLink:firstBaseTextChain.image(image).indentSpacer(4.0).baselineOffset(-6.0)];
     [imageChain appendLink:firstBaseTextChain.string(string1)];
     [imageChain appendLink:firstBaseTextChain.string(string2)];
 
@@ -63,28 +63,28 @@
 - (void)testIndentSpacer
 {
     BONChain *testChain;
-    XCTAssertNoThrow(testChain = BONChain.new.string(@"hello ").font([UIFont systemFontOfSize:12.0f]).indentSpacer(10.0f));
+    XCTAssertNoThrow(testChain = BONChain.new.string(@"hello ").font([UIFont systemFontOfSize:12.0]).indentSpacer(10.0));
     XCTAssertNotNil(testChain);
 
-    [testChain appendLink:BONChain.new.string(@"world").font([UIFont boldSystemFontOfSize:12.0f])];
+    [testChain appendLink:BONChain.new.string(@"world").font([UIFont boldSystemFontOfSize:12.0])];
 
     XCTAssertEqualObjects(testChain.attributedString.string, @"hello \tworld");
 
     NSMutableParagraphStyle *controlParagraphStyle = [[NSMutableParagraphStyle alloc] init];
     NSMutableParagraphStyle *indentedControlParagraphStyle = controlParagraphStyle.mutableCopy;
-    indentedControlParagraphStyle.headIndent = 41.0f;
+    indentedControlParagraphStyle.headIndent = 41.0;
     indentedControlParagraphStyle.tabStops = @[
-        [[NSTextTab alloc] initWithTextAlignment:NSTextAlignmentNatural location:41.0f options:@{}],
+        [[NSTextTab alloc] initWithTextAlignment:NSTextAlignmentNatural location:41.0 options:@{}],
     ];
 
     NSDictionary *controlAttributes = @{
         BONValueFromRange(0, 7) : @{
             NSParagraphStyleAttributeName : indentedControlParagraphStyle.copy,
-            NSFontAttributeName : [UIFont systemFontOfSize:12.0f],
+            NSFontAttributeName : [UIFont systemFontOfSize:12.0],
         },
         BONValueFromRange(7, 5) : @{
             NSParagraphStyleAttributeName : controlParagraphStyle.copy,
-            NSFontAttributeName : [UIFont boldSystemFontOfSize:12.0f],
+            NSFontAttributeName : [UIFont boldSystemFontOfSize:12.0],
         },
     };
     BONAssertAttributedStringHasAttributes(testChain.attributedString, controlAttributes);
@@ -93,28 +93,28 @@
 - (void)testZeroIndentSpacer
 {
     BONChain *testChain;
-    XCTAssertNoThrow(testChain = BONChain.new.string(@"hello ").font([UIFont systemFontOfSize:12.0f]).indentSpacer(0.0f));
+    XCTAssertNoThrow(testChain = BONChain.new.string(@"hello ").font([UIFont systemFontOfSize:12.0]).indentSpacer(0.0));
     XCTAssertNotNil(testChain);
 
-    [testChain appendLink:BONChain.new.string(@"world").font([UIFont boldSystemFontOfSize:12.0f])];
+    [testChain appendLink:BONChain.new.string(@"world").font([UIFont boldSystemFontOfSize:12.0])];
 
     XCTAssertEqualObjects(testChain.attributedString.string, @"hello \tworld");
 
     NSMutableParagraphStyle *controlParagraphStyle = [[NSMutableParagraphStyle alloc] init];
     NSMutableParagraphStyle *indentedControlParagraphStyle = controlParagraphStyle.mutableCopy;
-    indentedControlParagraphStyle.headIndent = 31.0f;
+    indentedControlParagraphStyle.headIndent = 31.0;
     indentedControlParagraphStyle.tabStops = @[
-        [[NSTextTab alloc] initWithTextAlignment:NSTextAlignmentNatural location:31.0f options:@{}],
+        [[NSTextTab alloc] initWithTextAlignment:NSTextAlignmentNatural location:31.0 options:@{}],
     ];
 
     NSDictionary *controlAttributes = @{
         BONValueFromRange(0, 7) : @{
             NSParagraphStyleAttributeName : indentedControlParagraphStyle.copy,
-            NSFontAttributeName : [UIFont systemFontOfSize:12.0f],
+            NSFontAttributeName : [UIFont systemFontOfSize:12.0],
         },
         BONValueFromRange(7, 5) : @{
             NSParagraphStyleAttributeName : controlParagraphStyle.copy,
-            NSFontAttributeName : [UIFont boldSystemFontOfSize:12.0f],
+            NSFontAttributeName : [UIFont boldSystemFontOfSize:12.0],
         },
     };
     BONAssertAttributedStringHasAttributes(testChain.attributedString, controlAttributes);

--- a/Example/Tests/BONPropertyClobberingTestCase.m
+++ b/Example/Tests/BONPropertyClobberingTestCase.m
@@ -6,11 +6,11 @@
 //  Copyright © 2015 Zev Eisenberg. All rights reserved.
 //
 
-@import XCTest;
+#import "BONBaseTestCase.h"
 
 @import BonMot;
 
-@interface BONPropertyClobberingTestCase : XCTestCase
+@interface BONPropertyClobberingTestCase : BONBaseTestCase
 
 @end
 
@@ -21,19 +21,19 @@
     BONText *text = [BONText new];
 
     XCTAssertEqual(text.adobeTracking, 0);
-    XCTAssertEqualWithAccuracy(text.pointTracking, 0.0f, 0.0001f);
+    XCTAssertEqualWithAccuracy(text.pointTracking, 0.0, kBONDoubleEpsilon);
 
     text.adobeTracking = 314;
     XCTAssertEqual(text.adobeTracking, 314);
-    XCTAssertEqualWithAccuracy(text.pointTracking, 0.0f, 0.0001f);
+    XCTAssertEqualWithAccuracy(text.pointTracking, 0.0, kBONDoubleEpsilon);
 
-    text.pointTracking = 2.718f;
+    text.pointTracking = 2.718;
     XCTAssertEqual(text.adobeTracking, 0);
-    XCTAssertEqualWithAccuracy(text.pointTracking, 2.718f, 0.0001f);
+    XCTAssertEqualWithAccuracy(text.pointTracking, 2.718, kBONDoubleEpsilon);
 
     text.adobeTracking = 42;
     XCTAssertEqual(text.adobeTracking, 42);
-    XCTAssertEqualWithAccuracy(text.pointTracking, 0.0f, 0.0001f);
+    XCTAssertEqualWithAccuracy(text.pointTracking, 0.0, kBONDoubleEpsilon);
 }
 
 - (void)testTrackingClobberingInBONChain
@@ -41,20 +41,20 @@
     BONChain *chain = [BONChain new];
 
     XCTAssertEqual(chain.text.adobeTracking, 0);
-    XCTAssertEqualWithAccuracy(chain.text.pointTracking, 0.0f, 0.0001f);
+    XCTAssertEqualWithAccuracy(chain.text.pointTracking, 0.0, kBONDoubleEpsilon);
 
     // Need to assing here because the chaining properties like .adobeTracking() copy, rather than mutating, the chain
     chain = chain.adobeTracking(314);
     XCTAssertEqual(chain.text.adobeTracking, 314);
-    XCTAssertEqualWithAccuracy(chain.text.pointTracking, 0.0f, 0.0001f);
+    XCTAssertEqualWithAccuracy(chain.text.pointTracking, 0.0, kBONDoubleEpsilon);
 
-    chain = chain.pointTracking(2.718f);
+    chain = chain.pointTracking(2.718);
     XCTAssertEqual(chain.text.adobeTracking, 0);
-    XCTAssertEqualWithAccuracy(chain.text.pointTracking, 2.718f, 0.0001f);
+    XCTAssertEqualWithAccuracy(chain.text.pointTracking, 2.718, kBONDoubleEpsilon);
 
     chain = chain.adobeTracking(42);
     XCTAssertEqual(chain.text.adobeTracking, 42);
-    XCTAssertEqualWithAccuracy(chain.text.pointTracking, 0.0f, 0.0001f);
+    XCTAssertEqualWithAccuracy(chain.text.pointTracking, 0.0, kBONDoubleEpsilon);
 }
 
 @end

--- a/Example/Tests/BONTextAlignmentConstraintTestCase.m
+++ b/Example/Tests/BONTextAlignmentConstraintTestCase.m
@@ -12,7 +12,7 @@
 static UILabel *testLabel(NSString *text, CGFloat fontSize)
 {
     UILabel *label = nil;
-    if (text && fontSize > 0.0f) {
+    if (text && fontSize > 0) {
         label = [[UILabel alloc] initWithFrame:CGRectZero];
         label.translatesAutoresizingMaskIntoConstraints = NO;
         label.text = text;
@@ -30,8 +30,8 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
 
 - (void)testTopConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     BONTextAlignmentConstraint *constraint = [BONTextAlignmentConstraint constraintWithItem:left
                                                                                   attribute:BONConstraintAttributeTop
@@ -44,8 +44,8 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
 
 - (void)testCapHeightConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     BONTextAlignmentConstraint *constraint = [BONTextAlignmentConstraint constraintWithItem:left
                                                                                   attribute:BONConstraintAttributeCapHeight
@@ -58,8 +58,8 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
 
 - (void)testXHeightConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     BONTextAlignmentConstraint *constraint = [BONTextAlignmentConstraint constraintWithItem:left
                                                                                   attribute:BONConstraintAttributeXHeight
@@ -72,8 +72,8 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
 
 - (void)testTopToCapHeightConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     BONTextAlignmentConstraint *constraint = [BONTextAlignmentConstraint constraintWithItem:left
                                                                                   attribute:BONConstraintAttributeTop
@@ -86,8 +86,8 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
 
 - (void)testCapHeightToTopConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     BONTextAlignmentConstraint *constraint = [BONTextAlignmentConstraint constraintWithItem:left
                                                                                   attribute:BONConstraintAttributeCapHeight
@@ -100,8 +100,8 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
 
 - (void)testTopToXHeightConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     BONTextAlignmentConstraint *constraint = [BONTextAlignmentConstraint constraintWithItem:left
                                                                                   attribute:BONConstraintAttributeTop
@@ -128,8 +128,8 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
 
 - (void)testCapHeightToXHeightConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     BONTextAlignmentConstraint *constraint = [BONTextAlignmentConstraint constraintWithItem:left
                                                                                   attribute:BONConstraintAttributeCapHeight
@@ -142,8 +142,8 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
 
 - (void)testXHeightToCapHeightConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     BONTextAlignmentConstraint *constraint = [BONTextAlignmentConstraint constraintWithItem:left
                                                                                   attribute:BONConstraintAttributeXHeight
@@ -156,8 +156,8 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
 
 - (void)testFirstBaselineConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     XCTAssertThrows([BONTextAlignmentConstraint constraintWithItem:left
                                                          attribute:BONConstraintAttributeFirstBaseline
@@ -168,8 +168,8 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
 
 - (void)testLastBaselineConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     XCTAssertThrows([BONTextAlignmentConstraint constraintWithItem:left
                                                          attribute:BONConstraintAttributeLastBaseline
@@ -180,8 +180,8 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
 
 - (void)testBottomConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     XCTAssertThrows([BONTextAlignmentConstraint constraintWithItem:left
                                                          attribute:BONConstraintAttributeBottom

--- a/Example/Tests/BONTextAlignmentConstraintTestCase.m
+++ b/Example/Tests/BONTextAlignmentConstraintTestCase.m
@@ -39,7 +39,7 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
                                                                                      toItem:right
                                                                                   attribute:BONConstraintAttributeTop];
 
-    XCTAssertEqualWithAccuracy(constraint.constant, 0.0f, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(constraint.constant, 0.0, kBONDoubleEpsilon);
 }
 
 - (void)testCapHeightConstraint
@@ -53,7 +53,7 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
                                                                                      toItem:right
                                                                                   attribute:BONConstraintAttributeCapHeight];
 
-    XCTAssertEqualWithAccuracy(constraint.constant, 8.1694f, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(constraint.constant, 8.1694, kBONDoubleEpsilon);
 }
 
 - (void)testXHeightConstraint
@@ -67,7 +67,7 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
                                                                                      toItem:right
                                                                                   attribute:BONConstraintAttributeXHeight];
 
-    XCTAssertEqualWithAccuracy(constraint.constant, 14.05078f, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(constraint.constant, 14.05078, kBONDoubleEpsilon);
 }
 
 - (void)testTopToCapHeightConstraint
@@ -81,7 +81,7 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
                                                                                      toItem:right
                                                                                   attribute:BONConstraintAttributeCapHeight];
 
-    XCTAssertEqualWithAccuracy(constraint.constant, 12.378f, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(constraint.constant, 12.378, kBONDoubleEpsilon);
 }
 
 - (void)testCapHeightToTopConstraint
@@ -95,7 +95,7 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
                                                                                      toItem:right
                                                                                   attribute:BONConstraintAttributeTop];
 
-    XCTAssertEqualWithAccuracy(constraint.constant, -4.20850f, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(constraint.constant, -4.20850, kBONDoubleEpsilon);
 }
 
 - (void)testTopToXHeightConstraint
@@ -109,13 +109,13 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
                                                                                      toItem:right
                                                                                   attribute:BONConstraintAttributeXHeight];
 
-    XCTAssertEqualWithAccuracy(constraint.constant, 21.289f, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(constraint.constant, 21.289, kBONDoubleEpsilon);
 }
 
 - (void)testXHeightToTopConstraint
 {
-    UILabel *left = testLabel(@"left", 17.0f);
-    UILabel *right = testLabel(@"right", 50.0f);
+    UILabel *left = testLabel(@"left", 17.0);
+    UILabel *right = testLabel(@"right", 50.0);
 
     BONTextAlignmentConstraint *constraint = [BONTextAlignmentConstraint constraintWithItem:left
                                                                                   attribute:BONConstraintAttributeXHeight
@@ -123,7 +123,7 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
                                                                                      toItem:right
                                                                                   attribute:BONConstraintAttributeTop];
 
-    XCTAssertEqualWithAccuracy(constraint.constant, -7.2382f, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(constraint.constant, -7.2382, kBONDoubleEpsilon);
 }
 
 - (void)testCapHeightToXHeightConstraint
@@ -137,7 +137,7 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
                                                                                      toItem:right
                                                                                   attribute:BONConstraintAttributeXHeight];
 
-    XCTAssertEqualWithAccuracy(constraint.constant, 17.0806f, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(constraint.constant, 17.0806, kBONDoubleEpsilon);
 }
 
 - (void)testXHeightToCapHeightConstraint
@@ -151,7 +151,7 @@ static UILabel *testLabel(NSString *text, CGFloat fontSize)
                                                                                      toItem:right
                                                                                   attribute:BONConstraintAttributeCapHeight];
 
-    XCTAssertEqualWithAccuracy(constraint.constant, 5.1396f, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(constraint.constant, 5.1396, kBONDoubleEpsilon);
 }
 
 - (void)testFirstBaselineConstraint

--- a/Example/Tests/BONTextAlignmentTestCase.m
+++ b/Example/Tests/BONTextAlignmentTestCase.m
@@ -106,15 +106,15 @@
     NSParagraphStyle *testParagraphStyle = testAttributes[NSParagraphStyleAttributeName];
     XCTAssertNotNil(testParagraphStyle);
     XCTAssertEqual(testParagraphStyle.alignment, NSTextAlignmentCenter);
-    XCTAssertEqualWithAccuracy(testParagraphStyle.firstLineHeadIndent, 1.23, kBONCGFloatEpsilon);
-    XCTAssertEqualWithAccuracy(testParagraphStyle.headIndent, 2.34, kBONCGFloatEpsilon);
-    XCTAssertEqualWithAccuracy(testParagraphStyle.tailIndent, 3.45, kBONCGFloatEpsilon);
-    XCTAssertEqualWithAccuracy(testParagraphStyle.lineHeightMultiple, 3.14, kBONCGFloatEpsilon);
-    XCTAssertEqualWithAccuracy(testParagraphStyle.maximumLineHeight, 5.67, kBONCGFloatEpsilon);
-    XCTAssertEqualWithAccuracy(testParagraphStyle.minimumLineHeight, 4.56, kBONCGFloatEpsilon);
-    XCTAssertEqualWithAccuracy(testParagraphStyle.lineSpacing, 2.72, kBONCGFloatEpsilon);
-    XCTAssertEqualWithAccuracy(testParagraphStyle.paragraphSpacing, 6.78, kBONCGFloatEpsilon);
-    XCTAssertEqualWithAccuracy(testParagraphStyle.paragraphSpacingBefore, 7.89, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.firstLineHeadIndent, 1.23, kBONDoubleEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.headIndent, 2.34, kBONDoubleEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.tailIndent, 3.45, kBONDoubleEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.lineHeightMultiple, 3.14, kBONDoubleEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.maximumLineHeight, 5.67, kBONDoubleEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.minimumLineHeight, 4.56, kBONDoubleEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.lineSpacing, 2.72, kBONDoubleEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.paragraphSpacing, 6.78, kBONDoubleEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.paragraphSpacingBefore, 7.89, kBONDoubleEpsilon);
 }
 
 // Test behavior when using both `headIndent` and `indentSpacer`
@@ -132,7 +132,7 @@
     NSAttributedString *testAttributedString = chain.attributedString;
 
     // The `indentSpacer` doesn't overwrite the `headIndent` value
-    XCTAssertEqualWithAccuracy(testParagraphStyle.headIndent, 1.23, kBONCGFloatEpsilon);
+    XCTAssertEqualWithAccuracy(testParagraphStyle.headIndent, 1.23, kBONDoubleEpsilon);
 
     [testAttributedString enumerateAttributesInRange:NSMakeRange(0, testAttributedString.length) options:0 usingBlock:^(BONStringDict *BONCNonnull attrs, NSRange range, BOOL *BONCNonnull stop) {
         NSParagraphStyle *paragraphStyle = attrs[NSParagraphStyleAttributeName];
@@ -141,10 +141,10 @@
 
             // The `indentSpacer` _does_ overwrite the `headIndent` value for the object replacement character and the inserted tab
             if ([substring isEqualToString:BONSpecial.objectReplacementCharacter] || [substring isEqualToString:BONSpecial.tab]) {
-                XCTAssertEqualWithAccuracy(paragraphStyle.headIndent, 40.0, kBONCGFloatEpsilon);
+                XCTAssertEqualWithAccuracy(paragraphStyle.headIndent, 40.0, kBONDoubleEpsilon);
             }
             else {
-                XCTAssertEqualWithAccuracy(paragraphStyle.headIndent, 1.23, kBONCGFloatEpsilon);
+                XCTAssertEqualWithAccuracy(paragraphStyle.headIndent, 1.23, kBONDoubleEpsilon);
             }
         }
     }];

--- a/Example/Tests/BONTrackingTestCase.m
+++ b/Example/Tests/BONTrackingTestCase.m
@@ -74,7 +74,7 @@
     NSAttributedString *attributedString =
         BONChain.new
             .string(@"Tracking is awesome!")
-            .font([UIFont systemFontOfSize:16.0f])
+            .font([UIFont systemFontOfSize:16.0])
             .adobeTracking(230)
             .attributedString;
 
@@ -85,12 +85,12 @@
     NSDictionary *controlAttributes = @{
         BONValueFromRange(0, 19) : @{
             NSKernAttributeName : @3.68,
-            NSFontAttributeName : [UIFont systemFontOfSize:16.0f],
+            NSFontAttributeName : [UIFont systemFontOfSize:16.0],
             NSParagraphStyleAttributeName : defaultParagraphStyle,
         },
 
         BONValueFromRange(19, 1) : @{
-            NSFontAttributeName : [UIFont systemFontOfSize:16.0f],
+            NSFontAttributeName : [UIFont systemFontOfSize:16.0],
             NSParagraphStyleAttributeName : defaultParagraphStyle,
         }
     };
@@ -132,7 +132,7 @@
     NSAttributedString *attributedString =
         BONChain.new
             .string(@"Tracking is awesome!")
-            .font([UIFont systemFontOfSize:16.0f])
+            .font([UIFont systemFontOfSize:16.0])
             .adobeTracking(-230)
             .attributedString;
 
@@ -143,12 +143,12 @@
     NSDictionary *controlAttributes = @{
         BONValueFromRange(0, 19) : @{
             NSKernAttributeName : @-3.68,
-            NSFontAttributeName : [UIFont systemFontOfSize:16.0f],
+            NSFontAttributeName : [UIFont systemFontOfSize:16.0],
             NSParagraphStyleAttributeName : defaultParagraphStyle,
         },
 
         BONValueFromRange(19, 1) : @{
-            NSFontAttributeName : [UIFont systemFontOfSize:16.0f],
+            NSFontAttributeName : [UIFont systemFontOfSize:16.0],
             NSParagraphStyleAttributeName : defaultParagraphStyle,
         }
     };

--- a/Pod/Classes/BONText.m
+++ b/Pod/Classes/BONText.m
@@ -12,7 +12,7 @@
 
 @import CoreText.SFNTLayoutTypes;
 
-static const CGFloat kBONAdobeTrackingDivisor = 1000.0f;
+static const CGFloat kBONAdobeTrackingDivisor = 1000.0;
 static const CGFloat kBONDefaultFontSize = 15.0; // per docs
 
 static inline BOOL BONDoublesCloseEnough(CGFloat float1, CGFloat float2)
@@ -77,7 +77,7 @@ static inline BOOL BONDoublesCloseEnough(CGFloat float1, CGFloat float2)
         attachment.image = self.image;
 
         // Use the native size of the image instead of allowing it to be scaled
-        attachment.bounds = CGRectMake(0.0f,
+        attachment.bounds = CGRectMake(0.0,
                                        self.baselineOffset, // images don’t respect attributed string’s baseline offset
                                        self.image.size.width,
                                        self.image.size.height);
@@ -249,9 +249,9 @@ static inline BOOL BONDoublesCloseEnough(CGFloat float1, CGFloat float2)
     }
 
     // Tracking
-    NSAssert(self.adobeTracking == 0 || self.pointTracking == 0.0f, @"You may set Adobe tracking or point tracking to nonzero values, but not both");
+    NSAssert(self.adobeTracking == 0 || self.pointTracking == 0.0, @"You may set Adobe tracking or point tracking to nonzero values, but not both");
 
-    CGFloat trackingInPoints = 0.0f;
+    CGFloat trackingInPoints = 0.0;
     if (self.adobeTracking != 0) {
         trackingInPoints = [self.class pointTrackingValueFromAdobeTrackingValue:self.adobeTracking forFont:fontToUse];
     }
@@ -265,70 +265,70 @@ static inline BOOL BONDoublesCloseEnough(CGFloat float1, CGFloat float2)
 
     // First Line Head Indent
 
-    if (self.firstLineHeadIndent != 0.0f) {
+    if (self.firstLineHeadIndent != 0.0) {
         populateParagraphStyleIfNecessary();
         paragraphStyle.firstLineHeadIndent = self.firstLineHeadIndent;
     }
 
     // Head Indent
 
-    if (self.headIndent != 0.0f) {
+    if (self.headIndent != 0.0) {
         populateParagraphStyleIfNecessary();
         paragraphStyle.headIndent = self.headIndent;
     }
 
     // Head Indent
 
-    if (self.tailIndent != 0.0f) {
+    if (self.tailIndent != 0.0) {
         populateParagraphStyleIfNecessary();
         paragraphStyle.tailIndent = self.tailIndent;
     }
 
     // Line Height
 
-    if (self.lineHeightMultiple != 1.0f) {
+    if (self.lineHeightMultiple != 1.0) {
         populateParagraphStyleIfNecessary();
         paragraphStyle.lineHeightMultiple = self.lineHeightMultiple;
     }
 
     // Maximum Line Height
 
-    if (self.maximumLineHeight != 1.0f) {
+    if (self.maximumLineHeight != 1.0) {
         populateParagraphStyleIfNecessary();
         paragraphStyle.maximumLineHeight = self.maximumLineHeight;
     }
 
     // Minimum Line Height
 
-    if (self.minimumLineHeight != 1.0f) {
+    if (self.minimumLineHeight != 1.0) {
         populateParagraphStyleIfNecessary();
         paragraphStyle.minimumLineHeight = self.minimumLineHeight;
     }
 
     // Line Spacing
 
-    if (self.lineSpacing != 0.0f) {
+    if (self.lineSpacing != 0.0) {
         populateParagraphStyleIfNecessary();
         paragraphStyle.lineSpacing = self.lineSpacing;
     }
 
     // Paragraph Spacing
 
-    if (self.paragraphSpacingAfter != 0.0f) {
+    if (self.paragraphSpacingAfter != 0.0) {
         populateParagraphStyleIfNecessary();
         paragraphStyle.paragraphSpacing = self.paragraphSpacingAfter;
     }
 
     // Paragraph Spacing Before
 
-    if (self.paragraphSpacingBefore != 0.0f) {
+    if (self.paragraphSpacingBefore != 0.0) {
         populateParagraphStyleIfNecessary();
         paragraphStyle.paragraphSpacingBefore = self.paragraphSpacingBefore;
     }
 
     // Baseline Offset
 
-    if (self.baselineOffset != 0.0f && !self.image) {
+    if (self.baselineOffset != 0.0 && !self.image) {
         attributes[NSBaselineOffsetAttributeName] = @(self.baselineOffset);
     }
 
@@ -435,7 +435,7 @@ static inline BOOL BONDoublesCloseEnough(CGFloat float1, CGFloat float2)
 {
     if (_adobeTracking != adobeTracking) {
         _adobeTracking = adobeTracking;
-        _pointTracking = 0.0f;
+        _pointTracking = 0.0;
     }
 }
 

--- a/Pod/Classes/BONText.m
+++ b/Pod/Classes/BONText.m
@@ -13,9 +13,9 @@
 @import CoreText.SFNTLayoutTypes;
 
 static const CGFloat kBONAdobeTrackingDivisor = 1000.0f;
-static const CGFloat kBONDefaultFontSize = 15.0f; // per docs
+static const CGFloat kBONDefaultFontSize = 15.0; // per docs
 
-static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
+static inline BOOL BONDoublesCloseEnough(CGFloat float1, CGFloat float2)
 {
     const CGFloat epsilon = 0.00001; // ought to be good enough
     return fabs(float1 - float2) < epsilon;
@@ -255,11 +255,11 @@ static inline BOOL BONCGFloatsCloseEnough(CGFloat float1, CGFloat float2)
     if (self.adobeTracking != 0) {
         trackingInPoints = [self.class pointTrackingValueFromAdobeTrackingValue:self.adobeTracking forFont:fontToUse];
     }
-    else if (!BONCGFloatsCloseEnough(self.pointTracking, 0.0f)) {
+    else if (!BONDoublesCloseEnough(self.pointTracking, 0.0)) {
         trackingInPoints = self.pointTracking;
     }
 
-    if (!BONCGFloatsCloseEnough(trackingInPoints, 0.0f)) {
+    if (!BONDoublesCloseEnough(trackingInPoints, 0.0)) {
         attributes[NSKernAttributeName] = @(trackingInPoints);
     }
 

--- a/Pod/Classes/BONTextAlignmentConstraint.m
+++ b/Pod/Classes/BONTextAlignmentConstraint.m
@@ -154,8 +154,8 @@ NSLayoutAttribute requiredLayoutAttributeForBONConstraintAttribute(BONConstraint
                                                                                   relatedBy:relation
                                                                                      toItem:view2
                                                                                   attribute:item2NSLayoutAttribute
-                                                                                 multiplier:1.0f
-                                                                                   constant:0.0f];
+                                                                                 multiplier:1.0
+                                                                                   constant:0.0];
     constraint.strongItem1 = view1;
     constraint.strongItem2 = view2;
     constraint.firstItemBONAttribute = attr1;
@@ -274,7 +274,7 @@ NSLayoutAttribute requiredLayoutAttributeForBONConstraintAttribute(BONConstraint
             break;
     }
 
-    CGFloat distanceFromTop = 0.0f;
+    CGFloat distanceFromTop = 0.0;
 
     if (bonConstraintAttribute != BONConstraintAttributeTop) {
         if ([item respondsToSelector:@selector(font)]) {

--- a/Pod/Classes/UIImage+BonMotUtilities.m
+++ b/Pod/Classes/UIImage+BonMotUtilities.m
@@ -20,14 +20,14 @@
     UIEdgeInsets originalAlignmentRectInsets = self.alignmentRectInsets;
 
     // Create image context
-    UIGraphicsBeginImageContextWithOptions(self.size, NO, 0.0f);
+    UIGraphicsBeginImageContextWithOptions(self.size, NO, 0.0);
     CGContextRef ctx = UIGraphicsGetCurrentContext();
 
     // Flip the context vertically
-    CGContextTranslateCTM(ctx, 0.0f, self.size.height);
-    CGContextScaleCTM(ctx, 1.0f, -1.0f);
+    CGContextTranslateCTM(ctx, 0.0, self.size.height);
+    CGContextScaleCTM(ctx, 1.0, -1.0);
 
-    CGRect imageRect = CGRectMake(0.0f, 0.0f, self.size.width, self.size.height);
+    CGRect imageRect = CGRectMake(0.0, 0.0, self.size.width, self.size.height);
 
     // Image tinting mostly inspired by http://stackoverflow.com/a/22528426/255489
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ NSString *quote = @"I used to love correcting people’s grammar until\
 —Mara Wilson";
 
 BONText *text = [BONText new];
-text.font = [UIFont fontWithName:@"AmericanTypewriter" size:17.0f];
-text.lineHeightMultiple = 1.8f;
+text.font = [UIFont fontWithName:@"AmericanTypewriter" size:17.0];
+text.lineHeightMultiple = 1.8;
 text.string = quote;
 
 NSAttributedString *string = text.attributedString;
@@ -84,8 +84,8 @@ NSString *quote = @"I used to love correcting people’s grammar until\
 // line-wrapped for readability
 NSAttributedString *attributedString =
 BONChain.new // [BONChain new] and [[BONChain alloc] init] also work
-.fontNameAndSize(@"AmericanTypewriter", 17.0f)
-.lineHeightMultiple(1.8f)
+.fontNameAndSize(@"AmericanTypewriter", 17.0)
+.lineHeightMultiple(1.8)
 .string(quote)
 .attributedString;
 ```
@@ -97,8 +97,8 @@ You can also create a local variable or property to save a partially-configured 
 // Base Chain
 BONChain *birdChain =
 BONChain.new
-.lineHeightMultiple(1.2f)
-.font([UIFont systemFontOfSize:17.0f])
+.lineHeightMultiple(1.2)
+.font([UIFont systemFontOfSize:17.0])
 .string(@"bird");
 
 // Two chains with different colors
@@ -155,7 +155,7 @@ BonMot uses `NSTextAttachment` to embed images in strings. Simply use the `.imag
 
 ```objc
 BONChain *chain = BONChain.new;
-[chain appendLink:BONChain.new.image(someUIImage).baselineOffset(-4.0f)];
+[chain appendLink:BONChain.new.image(someUIImage).baselineOffset(-4.0)];
 [chain appendLink:BONChain.new.text(@"label with icon") separator: @" "];
 NSAttributedString *string = chain.attributedString;
 ```
@@ -169,7 +169,7 @@ If you need to wrap multiple lines of text after an image, use the `indentSpacer
 ```objc
 NSString *quote = @"This is some text that goes on and on and spans multiple lines, and it all ends up left-aligned";
 BONChain *chain = BONChain.new;
-[chain appendLink:BONChain.new.image(someUIImage).indentSpacer(10.0f)];
+[chain appendLink:BONChain.new.image(someUIImage).indentSpacer(10.0)];
 [chain appendLink:BONChain.new.string(quote)];
 NSAttributedString *attributedString = chain.attributedString;
 ```


### PR DESCRIPTION
@nbonatsakis @ateliercw @arrouse I don't know if anyone still cares about the Objective-C style guide, but this defnitely goes against it in the interest of cleaning up these warnings without just disabling the warnings in the project. This is so that people can use this in their projects without having to inhibit warnings from BonMot.