### PR TITLE
Add support for hyphenationFactor

### DIFF
--- a/Pod/Classes/BONChain.h
+++ b/Pod/Classes/BONChain.h
@@ -32,6 +32,7 @@ typedef BONChain *BONCNonnull (^BONChainLineBreakMode)(NSLineBreakMode lineBreak
 typedef BONChain *BONCNonnull (^BONChainParagraphSpacingAfter)(CGFloat paragraphSpacing);
 typedef BONChain *BONCNonnull (^BONChainParagraphSpacingBefore)(CGFloat paragraphSpacingBefore);
 typedef BONChain *BONCNonnull (^BONChainBaselineOffset)(CGFloat baselineOffset);
+typedef BONChain *BONCNonnull (^BONChainHyphenationFactor)(CGFloat hyphenationFactor);
 typedef BONChain *BONCNonnull (^BONChainAlignment)(NSTextAlignment alignment);
 typedef BONChain *BONCNonnull (^BONChainFigureCase)(BONFigureCase figureCase);
 typedef BONChain *BONCNonnull (^BONChainFigureSpacing)(BONFigureSpacing figureSpacing);
@@ -77,6 +78,11 @@ typedef BONChain *BONCNonnull (^BONTagComplexStyles)(BONGeneric(NSArray, BONTag 
 @property (copy, nonatomic, readonly) BONChainParagraphSpacingBefore paragraphSpacingBefore;
 
 @property (copy, nonatomic, readonly) BONChainBaselineOffset baselineOffset;
+
+/**
+ *  Hyphenation is attempted when the ratio of the text width (as broken without hyphenation) to the width of the line fragment is less than the hyphenation factor. When the paragraph’s hyphenation factor is 0.0, the layout manager’s hyphenation factor is used instead. When both are 0.0, hyphenation is disabled.
+ */
+@property (copy, nonatomic, readonly) BONChainHyphenationFactor hyphenationFactor;
 
 @property (copy, nonatomic, readonly) BONChainAlignment alignment;
 

--- a/Pod/Classes/BONChain.m
+++ b/Pod/Classes/BONChain.m
@@ -244,6 +244,17 @@
     return [baselineOffsetBlock copy];
 }
 
+- (BONChainHyphenationFactor)hyphenationFactor
+{
+    BONChainHyphenationFactor hyphenationFactorBlock = ^(CGFloat hyphenationFactor) {
+        __typeof(self) newChain = self.copyWithoutNextText;
+        newChain.text.hyphenationFactor = hyphenationFactor;
+        return newChain;
+    };
+
+    return [hyphenationFactorBlock copy];
+}
+
 - (BONChainAlignment)alignment
 {
     BONChainAlignment alignmentBlock = ^(NSTextAlignment alignment) {

--- a/Pod/Classes/BONText.h
+++ b/Pod/Classes/BONText.h
@@ -61,6 +61,11 @@ typedef NS_ENUM(NSUInteger, BONFigureSpacing) {
 @property (nonatomic) CGFloat baselineOffset;
 
 /**
+ *  Hyphenation is attempted when the ratio of the text width (as broken without hyphenation) to the width of the line fragment is less than the hyphenation factor. When the paragraph’s hyphenation factor is 0.0, the layout manager’s hyphenation factor is used instead. When both are 0.0, hyphenation is disabled.
+ */
+@property (nonatomic) CGFloat hyphenationFactor;
+
+/**
  *  Defaults to @c NSTextAlignmentNatural.
  */
 @property (nonatomic) NSTextAlignment alignment;

--- a/Pod/Classes/BONText.m
+++ b/Pod/Classes/BONText.m
@@ -358,6 +358,13 @@ static inline BOOL BONDoublesCloseEnough(CGFloat float1, CGFloat float2)
         attributes[NSBaselineOffsetAttributeName] = @(self.baselineOffset);
     }
 
+    // Hyphenation Factor
+
+    if (self.hyphenationFactor != 0.0) {
+        populateParagraphStyleIfNecessary();
+        paragraphStyle.hyphenationFactor = self.hyphenationFactor;
+    }
+
     // Text Alignment
 
     if (self.alignment != NSTextAlignmentNatural) {
@@ -412,6 +419,7 @@ static inline BOOL BONDoublesCloseEnough(CGFloat float1, CGFloat float2)
     text.paragraphSpacingAfter = self.paragraphSpacingAfter;
     text.paragraphSpacingBefore = self.paragraphSpacingBefore;
     text.baselineOffset = self.baselineOffset;
+    text.hyphenationFactor = self.hyphenationFactor;
     text.alignment = self.alignment;
     text.figureCase = self.figureCase;
     text.figureSpacing = self.figureSpacing;

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ BonMot uses attributed strings to give you control over the following typographi
 - Paragraph spacing before
 - Paragraph spacing after
 - Baseline offset
+- Hyphenation factor (the threshold for hyphenating across line breaks)
 - Text alignment
 - Underlining and strikethrough
 - Figure case (uppercase vs. lowercase numbers)


### PR DESCRIPTION
This adds support to `BONText` and `BONChain` for `NSParagraphStyle`'s [`hyphenationFactor` property](https://developer.apple.com/library/ios/documentation/Cocoa/Reference/ApplicationKit/Classes/NSParagraphStyle_Class/#//apple_ref/occ/instp/NSParagraphStyle/hyphenationFactor). 