### PR TITLE
Feature/connorneville/Swift Code Samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,12 @@ Outputs:
 ## Image Attachments
 
 BonMot uses `NSTextAttachment` to embed images in strings. Simply use the `.image` property of a chain:
-
+```swift
+let chain = BONChain()
+chain.appendLink(BONChain().image(someUIImage).baselineOffset(-4.0))
+chain.appendLink(BONChain().string("label with icon"), separator: " ")
+let string = chain.attributedString
+```
 <details>
 <summary>Objective-C</summary>
 ```objc
@@ -221,7 +226,13 @@ Outputs:
 <img width=116 height=22 src="readme-images/label-with-icon.png" />
 
 If you need to wrap multiple lines of text after an image, use the `indentSpacer` property to align the whole paragraph after the image:
-
+```swift
+let quote = "This is some text that goes on and on and spans multiple lines, and it all ends up left-aligned"
+let chain = BONChain()
+chain.appendLink(BONChain().image(someUIImage).indentSpacer(10.0))
+chain.appendLink(BONChain().string(quote), separator: " ")
+let string = chain.attributedString
+```
 <details>
 <summary>Objective-C</summary>
 ```objc

--- a/README.md
+++ b/README.md
@@ -423,7 +423,6 @@ let string = chain.attributedString
 <summary>Objective-C</summary>
 ```objc
 BONChain *boldChain = BONChain.new.fontNameAndSize(@"Baskerville-Bold", 15.0f);
-BONChain *italicChain = BONChain.new.fontNameAndSize(@"Baskerville-Italic", 15.0f);
 
 BONChain *chain = BONChain.new.fontNameAndSize(@"Baskerville", 17.0f)
 .tagComplexStyles(@[BONTagComplexMake(@"~start~", @"!end", @"escape", boldChain)])

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Think something is missing? Please [file an issue](https://github.com/Raizlabs/B
 
 In any Swift file where you want to use BonMot, simply `import BonMot`. In Objective-C, that’s `#import <BonMot/BonMot.h>` or `@import BonMot`.
 
-The basic object in BonMot is `BONChain`, which allows you quickly construct attributed strings. You can create a chain with a normal `BonChain()` in Swift or either `[[BONChain alloc] init]`, `[BONChain new]` or `BONChain.new` in Objective-C:
+The basic object in BonMot is `BONChain`, which allows you quickly construct attributed strings. You can create a chain with a normal `BonChain()` in Swift or either `[[BONChain alloc] init]`, `[BONChain new]`, or `BONChain.new` in Objective-C:
 
 ```swift
 let quote = "I used to love correcting people's grammar until" +

--- a/README.md
+++ b/README.md
@@ -140,11 +140,14 @@ BONChain *blueBirds = birdChain.color([UIColor blueColor]);
 NSAttributedString *redBirdString = redBirds.attributedString;
 NSAttributedString *blueBirdString = blueBirds.attributedString;
 ```
+</details>
 
 ## Concatenation
 
 You can concatenate an array of `BONChain`s or `BONText`s:
 
+<details>
+<summary>Objective-C</summary>
 ```objc
 BONChain *oneFish = BONChain.new.string(@"one fish");
 BONChain *twoFish = BONChain.new.string(@"two fish");
@@ -154,6 +157,7 @@ BONChain *separator = BONChain.new.string(@", ");
 
 NSAttributedString *string = [BONText joinTextables:@[ oneFish, twoFish, redFish, blueFish ] withSeparator:separator];
 ```
+</details>
 
 Outputs:
 
@@ -161,6 +165,8 @@ Outputs:
 
 You can also append chains directly to each other:
 
+<details>
+<summary>Objective-C</summary>
 ```objc
 NSString *commaSpace = @", ";
 BONChain *chain = BONChain.new;
@@ -171,6 +177,7 @@ BONChain *chain = BONChain.new;
 
 NSAttributedString *string = chain.attributedString;
 ```
+</details>
 
 Outputs:
 
@@ -182,12 +189,15 @@ Outputs:
 
 BonMot uses `NSTextAttachment` to embed images in strings. Simply use the `.image` property of a chain:
 
+<details>
+<summary>Objective-C</summary>
 ```objc
 BONChain *chain = BONChain.new;
 [chain appendLink:BONChain.new.image(someUIImage).baselineOffset(-4.0)];
 [chain appendLink:BONChain.new.string(@"label with icon") separator: @" "];
 NSAttributedString *string = chain.attributedString;
 ```
+</details>
 
 Outputs:
 
@@ -195,6 +205,8 @@ Outputs:
 
 If you need to wrap multiple lines of text after an image, use the `indentSpacer` property to align the whole paragraph after the image:
 
+<details>
+<summary>Objective-C</summary>
 ```objc
 NSString *quote = @"This is some text that goes on and on and spans multiple lines, and it all ends up left-aligned";
 BONChain *chain = BONChain.new;
@@ -202,6 +214,7 @@ BONChain *chain = BONChain.new;
 [chain appendLink:BONChain.new.string(quote)];
 NSAttributedString *attributedString = chain.attributedString;
 ```
+</details>
 
 Outputs:
 
@@ -227,6 +240,8 @@ BonMot provides a `bonTextable` property on `UILabel`, `UITextView`, and `UIText
 
 **Note:** to use these utilities, add `pod 'BonMot/UIKit'` to your Podfile.
 
+<details>
+<summary>Objective-C</summary>
 ```objc
 UILabel *label = [[UILabel alloc] init];
 
@@ -235,6 +250,7 @@ BONChain *chain = BONChain.new.adobeTracking(300).fontNameAndSize(@"Avenir-Book"
 label.bonTextable = chain;
 [label setBonString:@"Some initial text."];
 ```
+</details>
 
 Outputs:
 
@@ -242,13 +258,19 @@ Outputs:
 
 Some time later, you can update the text of the label with a plain string, without losing the original styling from the `BONTextable`.
 
+<details>
+<summary>Objective-C</summary>
 ```objc
 label.bonString = @"Some updated text."; // this shorthand is valid in Obj-C
 ```
+</details>
 
+<details>
+<summary>Objective-C</summary>
 ```swift
 label.setBonString("Some updated text.") // Here’s the Swift equivalent
 ```
+</details>
 
 Outputs:
 
@@ -266,6 +288,8 @@ UIKit lets you align labels by top, bottom, or baseline. BonMot includes `BONTex
 
 You can use `BONTextAlignmentConstraint` programmatically or in Interface Builder. In code, use the convenience initializer:
 
+<details>
+<summary>Objective-C</summary>
 ```objc
 [BONTextAlignmentConstraint constraintWithItem:someLabel
                                      attribute:BONConstraintAttributeCapHeight
@@ -273,6 +297,7 @@ You can use `BONTextAlignmentConstraint` programmatically or in Interface Builde
                                         toItem:someOtherLabel
                                      attribute:BONConstraintAttributeCapHeight].active = YES;
 ```
+</details>
 
 In Interface Builder, start by constraining two views to each other with a `top` constraint. Select the constraint, and in the Identity Inspector, change the class to `BONTextAlignmentConstraint`:
 
@@ -290,6 +315,8 @@ The layout won’t change in Interface Builder (IBDesignable is not supported fo
 
 `-[NSAttributedString bon_humanReadableString]` expands special characters out into human-readable strings. This is useful for writing unit tests where you need to compare a BonMot-generated string with an example string which may contain invisible or hard-to-read characters. For example, here’s a string with an embedded image, a non-breaking space, and some text that contains an en dash:
 
+<details>
+<summary>Objective-C</summary>
 ```objc
 BONChain *chain = BONChain.new.image(someImage);
 [chain appendLink:BONChain.new.string(BONSpecial.noBreakSpace)];
@@ -299,6 +326,7 @@ BONChain *chain = BONChain.new.image(someImage);
 
 NSLog(@"%@", chain.attributedString.bon_humanReadableString);
 ```
+</details>
 
 Prints this:
 
@@ -310,6 +338,8 @@ Prints this:
 
 BonMot can style text between arbirtrary tags using a `<tag></tag>` format and `\` as an escape character. This allows you to apply styles to substrings of localized strings, whose position, order, and even existence may change from language to language.
 
+<details>
+<summary>Objective-C</summary>
 ```objc
 BONChain *boldChain = BONChain.new.fontNameAndSize(@"Baskerville-Bold", 15.0f);
 BONChain *italicChain = BONChain.new.fontNameAndSize(@"Baskerville-Italic", 15.0f);
@@ -320,6 +350,7 @@ BONChain *chain = BONChain.new.fontNameAndSize(@"Baskerville", 17.0f)
 
 NSAttributedString *string = chain.attributedString;
 ```
+</details>
 
 Outputs:
 
@@ -327,6 +358,8 @@ Outputs:
 
 BonMot can also style text between any arbitrary start and end strings using any escape string.
 
+<details>
+<summary>Objective-C</summary>
 ```objc
 BONChain *boldChain = BONChain.new.fontNameAndSize(@"Baskerville-Bold", 15.0f);
 BONChain *italicChain = BONChain.new.fontNameAndSize(@"Baskerville-Italic", 15.0f);
@@ -337,6 +370,7 @@ BONChain *chain = BONChain.new.fontNameAndSize(@"Baskerville", 17.0f)
 
 NSAttributedString *string = chain.attributedString;
 ```
+</details>
 
 Outputs:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Think something is missing? Please [file an issue](https://github.com/Raizlabs/B
 
 In any Swift file where you want to use BonMot, simply `import BonMot`. In Objective-C, that’s `#import <BonMot/BonMot.h>` or `@import BonMot`.
 
-The basic object in BonMot is `BONChain`, which allows you quickly construct attributed strings. You can create a chain with a normal `[[BONChain alloc] init]`, but it's easier to just use `[BONChain new]` or the even shorter and technically valid `BONChain.new`:
+The basic object in BonMot is `BONChain`, which allows you quickly construct attributed strings. You can create a chain with a normal `BonChain()` in Swift or either `[[BONChain alloc] init]`, `[BONChain new]` or `BONChain.new` in Objective-C:
 
 ```swift
 let quote = "I used to love correcting people's grammar until" +

--- a/README.md
+++ b/README.md
@@ -145,7 +145,15 @@ NSAttributedString *blueBirdString = blueBirds.attributedString;
 ## Concatenation
 
 You can concatenate an array of `BONChain`s or `BONText`s:
+```swift
+let oneFish = BONChain().string("one fish")
+let twoFish = BONChain().string("two fish")
+let redFish = BONChain().string("red fish").color(.redColor())
+let blueFish = BONChain().string("blue fish").color(.blueColor())
+let separator = BONChain().string(", ")
 
+let string = BONText.joinTextables([oneFish, twoFish, redFish, blueFish], withSeparator: separator)
+```
 <details>
 <summary>Objective-C</summary>
 ```objc
@@ -258,6 +266,9 @@ Outputs:
 
 Some time later, you can update the text of the label with a plain string, without losing the original styling from the `BONTextable`.
 
+```swift
+label.setBonString("Some updated text.")
+```
 <details>
 <summary>Objective-C</summary>
 ```objc
@@ -265,12 +276,6 @@ label.bonString = @"Some updated text."; // this shorthand is valid in Obj-C
 ```
 </details>
 
-<details>
-<summary>Objective-C</summary>
-```swift
-label.setBonString("Some updated text.") // Here’s the Swift equivalent
-```
-</details>
 
 Outputs:
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ BONChain.new // [BONChain new] and [[BONChain alloc] init] also work
 
 You can also create a local variable or property to save a partially-configured chain. All the chaining methods pass copies of the chain, so you don't have to worry about later changes clobbering earlier properties:
 
+```swift
+// Base Chain
+let birdChain = BONChain()
+    .lineHeightMultiple(1.2)
+    .font(UIFont.systemFontOfSize(17.0))
+    .string("bird")
+
+// Two chains with different colors
+// that inherit their parents' properties
+let redBirds = birdChain.color(.redColor())
+let blueBirds = birdChain.color(.blueColor())
+
+// Two different attributed strings with all attributes shared
+// except for text color
+let redBirdString = redBirds.attributedString
+let blueBirdString = blueBirds.attributedString
+```
+<details>
+<summary>Objective-C</summary>
 ```objc
 // Base Chain
 BONChain *birdChain =
@@ -114,6 +133,7 @@ BONChain.new
 // that inherit their parents’ properties
 BONChain *redBirds = birdChain.color([UIColor redColor]);
 BONChain *blueBirds = birdChain.color([UIColor blueColor]);
+</details>
 
 // two different attributed strings with all attributes shared
 // except for text color

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ The layout won’t change in Interface Builder (IBDesignable is not supported fo
 
 ## Unit Testing helpers
 
-`-[NSAttributedString bon_humanReadableString]` expands special characters out into human-readable strings. This is useful for writing unit tests where you need to compare a BonMot-generated string with an example string which may contain invisible or hard-to-read characters. For example, here’s a string with an embedded image, a non-breaking space, and some text that contains an en dash:
+NSAttributedString's `bon_humanReadableString` expands special characters out into human-readable strings. This is useful for writing unit tests where you need to compare a BonMot-generated string with an example string which may contain invisible or hard-to-read characters. For example, here’s a string with an embedded image, a non-breaking space, and some text that contains an en dash:
 
 <details>
 <summary>Objective-C</summary>

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ In any Swift file where you want to use BonMot, simply `import BonMot`. In Objec
 
 The basic object in BonMot is `BONChain`, which allows you quickly construct attributed strings. You can create a chain with a normal `[[BONChain alloc] init]`, but it's easier to just use `[BONChain new]` or the even shorter and technically valid `BONChain.new`:
 
+<details>
+<summary>Objective-C</summary>
 ```objc
 NSString *quote = @"I used to love correcting people’s grammar until\
  I realized what I loved more was having friends.\n\
@@ -82,6 +84,7 @@ BONChain.new // [BONChain new] and [[BONChain alloc] init] also work
                        // and get back a dictionary of attributes
 
 ```
+</details>
 
 You can also create a local variable or property to save a partially-configured chain. All the chaining methods pass copies of the chain, so you don't have to worry about later changes clobbering earlier properties:
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,13 @@ UIKit lets you align labels by top, bottom, or baseline. BonMot includes `BONTex
 
 You can use `BONTextAlignmentConstraint` programmatically or in Interface Builder. In code, use the convenience initializer:
 
+```swift
+BONTextAlignmentConstraint(item: someLabel,
+                      attribute: BONConstraintAttribute.CapHeight,
+                      relatedBy: .Equal,
+                         toItem: someOtherLabel,
+                      attribute: BONConstraintAttribute.CapHeight).active = true
+```
 <details>
 <summary>Objective-C</summary>
 ```objc
@@ -344,8 +351,15 @@ The layout won’t change in Interface Builder (IBDesignable is not supported fo
 
 ## Unit Testing helpers
 
-NSAttributedString's `bon_humanReadableString` expands special characters out into human-readable strings. This is useful for writing unit tests where you need to compare a BonMot-generated string with an example string which may contain invisible or hard-to-read characters. For example, here’s a string with an embedded image, a non-breaking space, and some text that contains an en dash:
-
+The `bon_humanReadableString` category method on `NSAttributedString` expands special characters out into human-readable strings. This is useful for writing unit tests where you need to compare a BonMot-generated string with an example string which may contain invisible or hard-to-read characters. For example, here’s a string with an embedded image, a non-breaking space, and some text that contains an en dash:
+```swift
+let chain = BONChain().image(someImage)
+chain.appendLink(BONChain().string(BONSpecial.noBreakSpace()))
+chain.appendLink(BONChain().string("Monday"))
+chain.appendLink(BONChain().string(BONSpecial.enDash()))
+chain.appendLink(BONChain().string("Friday"))
+print(chain.attributedString.bon_humanReadableString)
+```
 <details>
 <summary>Objective-C</summary>
 ```objc
@@ -368,7 +382,16 @@ Prints this:
 ## Tag Styles
 
 BonMot can style text between arbirtrary tags using a `<tag></tag>` format and `\` as an escape character. This allows you to apply styles to substrings of localized strings, whose position, order, and even existence may change from language to language.
+```swift
+let boldChain = BONChain().fontNameAndSize("Basketville-Bold", 15.0)
+let italicChain = BONChain().fontNameAndSize("Basketville-Italic", 15.0)
 
+let chain = BONChain().fontNameAndSize("Basketville", 17.0)
+    .tagStyles(["bold": boldChain, "italic": italicChain])
+    .string("<bold>This text</bold> contains a \\<bold> tag.\n" +
+            "<italic>This text</italic> contains a \\<italic> tag.")
+let string = chain.attributedString
+```
 <details>
 <summary>Objective-C</summary>
 ```objc
@@ -388,7 +411,14 @@ Outputs:
 <img width=275 height=40 src="readme-images/tag-styling.png" />
 
 BonMot can also style text between any arbitrary start and end strings using any escape string.
+```swift
+let boldChain = BONChain().fontNameAndSize("Basketville-Bold", 15.0)
 
+let chain = BONChain().fontNameAndSize("Basketville", 17.0)
+.tagComplexStyles([BONTag(startTag: "~start", endTag: "!end", escapeString: "escape", textable: boldChain)])
+.string("~start~This text is wrapped in a escape~start~ tag.!end")
+let string = chain.attributedString
+```
 <details>
 <summary>Objective-C</summary>
 ```objc

--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ In any Swift file where you want to use BonMot, simply `import BonMot`. In Objec
 
 The basic object in BonMot is `BONChain`, which allows you quickly construct attributed strings. You can create a chain with a normal `[[BONChain alloc] init]`, but it's easier to just use `[BONChain new]` or the even shorter and technically valid `BONChain.new`:
 
+```swift
+let quote = "I used to love correcting people's grammar until\"" +
+"I realized what I loved more was having friends.\n\"" +
+"-Mara Wilson"
+
+// line-wrapped for readability
+let attributedString =
+BONChain()
+.lineHeightMultiple(1.2)
+.fontNameAndSize("AmericanTypewriter", 17.0)
+.string(quote)
+.attributedString   // You can also query .attributes
+// and get back a dictionary of attributes
+```
 <details>
 <summary>Objective-C</summary>
 ```objc

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ let birdChain = BONChain()
     .string("bird")
 
 // Two chains with different colors
-// that inherit their parents' properties
+// that inherit their parents’ properties
 let redBirds = birdChain.color(.redColor())
 let blueBirds = birdChain.color(.blueColor())
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ let quote = "I used to love correcting people's grammar until" +
             "-Mara Wilson"
 
 // line-wrapped for readability
-let attributedString =
-    BONChain()
+let attributedString = BONChain()
     .lineHeightMultiple(1.2)
     .fontNameAndSize("AmericanTypewriter", 17.0)
     .string(quote)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,16 @@ Outputs:
 <img width=227 src="readme-images/fish-with-black-comma.png" />
 
 You can also append chains directly to each other:
+```swift
+let commaSpace = ", "
+let chain = BONChain()
+chain.appendLink(BONChain().string("one fish"))
+chain.appendLink(BONChain().string("two fish"), separator: commaSpace)
+chain.appendLink(BONChain().string("red fish").color(.redColor()), separator: commaSpace)
+chain.appendLink(BONChain().string("blue fish").color(.blueColor()), separator: commaSpace)
 
+let string = chain.attributedString
+```
 <details>
 <summary>Objective-C</summary>
 ```objc

--- a/README.md
+++ b/README.md
@@ -383,10 +383,10 @@ Prints this:
 
 BonMot can style text between arbirtrary tags using a `<tag></tag>` format and `\` as an escape character. This allows you to apply styles to substrings of localized strings, whose position, order, and even existence may change from language to language.
 ```swift
-let boldChain = BONChain().fontNameAndSize("Basketville-Bold", 15.0)
-let italicChain = BONChain().fontNameAndSize("Basketville-Italic", 15.0)
+let boldChain = BONChain().fontNameAndSize("Baskerville-Bold", 15.0)
+let italicChain = BONChain().fontNameAndSize("Baskerville-Italic", 15.0)
 
-let chain = BONChain().fontNameAndSize("Basketville", 17.0)
+let chain = BONChain().fontNameAndSize("Baskerville", 17.0)
     .tagStyles(["bold": boldChain, "italic": italicChain])
     .string("<bold>This text</bold> contains a \\<bold> tag.\n" +
             "<italic>This text</italic> contains a \\<italic> tag.")
@@ -412,11 +412,11 @@ Outputs:
 
 BonMot can also style text between any arbitrary start and end strings using any escape string.
 ```swift
-let boldChain = BONChain().fontNameAndSize("Basketville-Bold", 15.0)
+let boldChain = BONChain().fontNameAndSize("Baskerville-Bold", 15.0)
 
-let chain = BONChain().fontNameAndSize("Basketville", 17.0)
-.tagComplexStyles([BONTag(startTag: "~start", endTag: "!end", escapeString: "escape", textable: boldChain)])
-.string("~start~This text is wrapped in a escape~start~ tag.!end")
+let chain = BONChain().fontNameAndSize("Baskerville", 17.0)
+    .tagComplexStyles([BONTag(startTag: "~start", endTag: "!end", escapeString: "escape", textable: boldChain)])
+    .string("~start~This text is wrapped in a escape~start~ tag.!end")
 let string = chain.attributedString
 ```
 <details>

--- a/README.md
+++ b/README.md
@@ -267,7 +267,14 @@ BonMot provides several utilities that enhance its interoperability with UIKit.
 BonMot provides a `bonTextable` property on `UILabel`, `UITextView`, and `UITextField` that allows assigning a `BONTextable` object to apply styling to any strings assigned via the `-setBonString:` method (or `.bonString = ...` in Objective-C).
 
 **Note:** to use these utilities, add `pod 'BonMot/UIKit'` to your Podfile.
+```swift
+let label = UILabel()
 
+let chain = BONChain().adobeTracking(300).fontNameAndSize("Avenir-Book", 18.0)
+
+label.bonTextable = chain
+label.setBonString("Some initial text.")
+```
 <details>
 <summary>Objective-C</summary>
 ```objc

--- a/README.md
+++ b/README.md
@@ -68,18 +68,18 @@ In any Swift file where you want to use BonMot, simply `import BonMot`. In Objec
 The basic object in BonMot is `BONChain`, which allows you quickly construct attributed strings. You can create a chain with a normal `[[BONChain alloc] init]`, but it's easier to just use `[BONChain new]` or the even shorter and technically valid `BONChain.new`:
 
 ```swift
-let quote = "I used to love correcting people's grammar until\"" +
-"I realized what I loved more was having friends.\n\"" +
-"-Mara Wilson"
+let quote = "I used to love correcting people's grammar until" +
+            "I realized what I loved more was having friends.\n" +
+            "-Mara Wilson"
 
 // line-wrapped for readability
 let attributedString =
-BONChain()
-.lineHeightMultiple(1.2)
-.fontNameAndSize("AmericanTypewriter", 17.0)
-.string(quote)
-.attributedString   // You can also query .attributes
-// and get back a dictionary of attributes
+    BONChain()
+    .lineHeightMultiple(1.2)
+    .fontNameAndSize("AmericanTypewriter", 17.0)
+    .string(quote)
+    .attributedString   // You can also query .attributes
+                        // and get back a dictionary of attributes
 ```
 <details>
 <summary>Objective-C</summary>


### PR DESCRIPTION
Adds Swift equivalents for Readme code samples and puts Objective C versions in disclosable sections.
fixes #152 