### PR TITLE
[4.0] Fix debugRepresentation

### DIFF
--- a/Example/BonMot-Example-iOS/DemoStrings.swift
+++ b/Example/BonMot-Example-iOS/DemoStrings.swift
@@ -25,9 +25,9 @@ enum DemoStrings {
 
         return NSAttributedString.composed(of   : [
             "I want to be different. If everyone is wearing ",
-            " black, ".styled(with: black),
+            "\(Special.noBreakSpace)black,\(Special.noBreakSpace)".styled(with: black),
             " I want to be wearing ",
-            " red. ".styled(with: red),
+            "\(Special.noBreakSpace)red.\(Special.noBreakSpace)".styled(with: red),
             "\nMaria Sharapova ".styled(with: signed),
             racket
             ], baseStyle: gray)
@@ -57,7 +57,7 @@ enum DemoStrings {
                 ]
             )
         )
-        return "I want to be different. If everyone is wearing <black> black, </black> I want to be wearing <red> red. </red>\n<signed>Maria Sharapova</signed> <racket/>".styled(with: baseStyle)
+        return "I want to be different. If everyone is wearing <black><BON:noBreakSpace/>black,<BON:noBreakSpace/></black> I want to be wearing <red><BON:noBreakSpace/>red.<BON:noBreakSpace/></red>\n<signed>Maria Sharapova</signed> <racket/>".styled(with: baseStyle)
     }()
 
     static let trackingString = "Adults are always asking kids what they want to be when they grow up because they are looking for ideas.\n—Paula Poundstone"

--- a/Sources/AttributedStringStylePart.swift
+++ b/Sources/AttributedStringStylePart.swift
@@ -151,7 +151,8 @@ extension AttributedStringStyle {
             self.paragraphSpacingBefore = paragraphSpacingBefore
         case .xml:
             self.xmlStyler = NSAttributedString.defaultXMLStyler
-        case let .xmlRules(rules):
+        case var .xmlRules(rules):
+            rules.append(contentsOf: Special.insertionRules)
             self.xmlStyler = XMLRuleStyler(rules: rules)
         case let .xmlStyler(xmlStyler):
             self.xmlStyler = xmlStyler

--- a/Sources/NSAttributedString+BonMot.swift
+++ b/Sources/NSAttributedString+BonMot.swift
@@ -51,7 +51,7 @@ extension NSAttributedString {
         replacements = []
 
         let unassignedPrefix = "\\N{<unassigned-"
-        let unassignedPrefixReplacement = "<BON:unassigned unicode='"
+        let unassignedPrefixReplacement = "<BON:unicode value='"
         let unassignedSuffix = ">}"
         let unassignedSuffixReplacement = "'/>"
 

--- a/Sources/NSAttributedString+BonMot.swift
+++ b/Sources/NSAttributedString+BonMot.swift
@@ -15,8 +15,7 @@ extension NSAttributedString {
 
     /// Create a new attributed string based on the current string, but replace characters in the Special enumeration,
     /// images, and unassigned unicode characters with a visual string.
-    @objc(bon_debugRepresentation)
-    public var debugRepresentation: NSAttributedString {
+    public var bonMotDebugAttributedString: NSAttributedString {
         let debug = self.mutableStringCopy()
         var replacements = Array<(range: NSRange, string: String)>()
         var index = 0
@@ -76,6 +75,10 @@ extension NSAttributedString {
         }
 
         return debug
+    }
+
+    public var bonMotDebugString: String {
+        return bonMotDebugAttributedString.string
     }
 
 }

--- a/Sources/XMLBuilder.swift
+++ b/Sources/XMLBuilder.swift
@@ -75,7 +75,7 @@ extension NSAttributedString {
 }
 
 extension Special {
-    static var insertionRules: [XMLStyleRule] {
+    public static var insertionRules: [XMLStyleRule] {
         let rulePairs: [[XMLStyleRule]] = all.map() {
             let elementName = "BON:\($0.name)"
             // Add the insertion rule and a style rule so we don't lookup the style and generate a warning

--- a/Tests/AttributedStringStyleTests.swift
+++ b/Tests/AttributedStringStyleTests.swift
@@ -32,7 +32,6 @@ class AttributedStringStyleTests: XCTestCase {
             let font = style.attributes[NSFontAttributeName] as? UIFont
             let fontTextStyle = font?.textStyle
             XCTAssertEqual(fontTextStyle, titleTextStyle)
-            print(fontTextStyle, titleTextStyle)
         }
     }
     #endif

--- a/Tests/Compatibility.swift
+++ b/Tests/Compatibility.swift
@@ -199,6 +199,10 @@ import BonMot
         func data(using encoding: NSStringEncoding, allowLossyConversion: Bool = false) -> NSData? {
             return dataUsingEncoding(encoding, allowLossyConversion: allowLossyConversion)
         }
+        func contains(other: String) -> Bool {
+            return containsString(other)
+        }
+
     }
 #endif
 

--- a/Tests/NSAttributedStringDebugTests.swift
+++ b/Tests/NSAttributedStringDebugTests.swift
@@ -30,7 +30,7 @@ class NSAttributedStringDebugTests: XCTestCase {
         ]
         for (index, testCase) in testCases.enumerated() {
             let line = UInt(#line - testCases.count - 2 + index)
-            let debugString = NSAttributedString(string: testCase.0).debugRepresentation.string
+            let debugString = NSAttributedString(string: testCase.0).bonMotDebugString
             XCTAssertEqual(testCase.1, debugString, line: line)
             let fromXML = AttributedStringStyle.style(.xml).attributedString(from: debugString)
             // Unassigned unicode replacement is not currently working. No one is actually interested in doing this so I'm going to leave it out.
@@ -41,7 +41,7 @@ class NSAttributedStringDebugTests: XCTestCase {
     }
 
     func testImageRepresentationHasSize() {
-        XCTAssertEqual(imageForTest.attributedString().debugRepresentation.string, "<BON:image size='36x36'/>")
+        XCTAssertEqual(imageForTest.attributedString().bonMotDebugString, "<BON:image size='36x36'/>")
     }
 
     func testThatNSAttributedStringSpeaksUTF16() {

--- a/Tests/NSAttributedStringDebugTests.swift
+++ b/Tests/NSAttributedStringDebugTests.swift
@@ -26,6 +26,7 @@ class NSAttributedStringDebugTests: XCTestCase {
             ("Floppy💾Disk", "Floppy💾Disk"),
             ("\u{000A1338}A\u{000A1339}", "{unassignedUnicode<A1338>}A{unassignedUnicode<A1339>}"),
             ("neonسلام🚲\u{000A1338}₫\u{000A1339}", "neonسلام🚲{unassignedUnicode<A1338>}₫{unassignedUnicode<A1339>}"),
+            ("\n →\t", "{lineFeed} →{tab}"),
         ]
         for (index, testCase) in testCases.enumerated() {
             let line = UInt(#line - testCases.count - 2 + index)

--- a/Tests/NSAttributedStringDebugTests.swift
+++ b/Tests/NSAttributedStringDebugTests.swift
@@ -24,19 +24,24 @@ class NSAttributedStringDebugTests: XCTestCase {
             ("it ignores spaces", "it ignores spaces"),
             ("Pilcrow¶", "Pilcrow¶"),
             ("Floppy💾Disk", "Floppy💾Disk"),
-            ("\u{000A1338}A\u{000A1339}", "<BON:unassigned unicode='A1338'/>A<BON:unassigned unicode='A1339'/>"),
-            ("neonسلام🚲\u{000A1338}₫\u{000A1339}", "neonسلام🚲<BON:unassigned unicode='A1338'/>₫<BON:unassigned unicode='A1339'/>"),
+            ("\u{000A1338}A\u{000A1339}", "<BON:unicode value='A1338'/>A<BON:unicode value='A1339'/>"),
+            ("neonسلام🚲\u{000A1338}₫\u{000A1339}", "neonسلام🚲<BON:unicode value='A1338'/>₫<BON:unicode value='A1339'/>"),
             ("\n →\t", "<BON:lineFeed/> →<BON:tab/>"),
         ]
         for (index, testCase) in testCases.enumerated() {
             let line = UInt(#line - testCases.count - 2 + index)
             let debugString = NSAttributedString(string: testCase.0).debugRepresentation.string
             XCTAssertEqual(testCase.1, debugString, line: line)
+            let fromXML = AttributedStringStyle.style(.xml).attributedString(from: debugString)
+            // Unassigned unicode replacement is not currently working. No one is actually interested in doing this so I'm going to leave it out.
+            if !testCase.1.contains("BON:unicode value=") {
+                XCTAssertEqual(testCase.0, fromXML.string, line: line)
+            }
         }
     }
 
     func testImageRepresentationHasSize() {
-        XCTAssertEqual(imageForTest.attributedString().debugRepresentation.string, "<BON:image size='36x36'/>       ")
+        XCTAssertEqual(imageForTest.attributedString().debugRepresentation.string, "<BON:image size='36x36'/>")
     }
 
     func testThatNSAttributedStringSpeaksUTF16() {

--- a/Tests/NSAttributedStringDebugTests.swift
+++ b/Tests/NSAttributedStringDebugTests.swift
@@ -27,6 +27,7 @@ class NSAttributedStringDebugTests: XCTestCase {
             ("\u{000A1338}A\u{000A1339}", "<BON:unicode value='A1338'/>A<BON:unicode value='A1339'/>"),
             ("neonسلام🚲\u{000A1338}₫\u{000A1339}", "neonسلام🚲<BON:unicode value='A1338'/>₫<BON:unicode value='A1339'/>"),
             ("\n →\t", "<BON:lineFeed/> →<BON:tab/>"),
+            ("foo\u{00a0}bar", "foo<BON:noBreakSpace/>bar"),
         ]
         for (index, testCase) in testCases.enumerated() {
             let line = UInt(#line - testCases.count - 2 + index)

--- a/Tests/NSAttributedStringDebugTests.swift
+++ b/Tests/NSAttributedStringDebugTests.swift
@@ -19,14 +19,14 @@ class NSAttributedStringDebugTests: XCTestCase {
     func testDebugRepresentationReplacements() {
         let testCases: [(String, String)] = [
             ("BonMot", "BonMot"),
-            ("Bon\tMot", "Bon{tab}Mot"),
-            ("Bon\nMot", "Bon{lineFeed}Mot"),
+            ("Bon\tMot", "Bon<BON:tab/>Mot"),
+            ("Bon\nMot", "Bon<BON:lineFeed/>Mot"),
             ("it ignores spaces", "it ignores spaces"),
             ("Pilcrow¶", "Pilcrow¶"),
             ("Floppy💾Disk", "Floppy💾Disk"),
-            ("\u{000A1338}A\u{000A1339}", "{unassignedUnicode<A1338>}A{unassignedUnicode<A1339>}"),
-            ("neonسلام🚲\u{000A1338}₫\u{000A1339}", "neonسلام🚲{unassignedUnicode<A1338>}₫{unassignedUnicode<A1339>}"),
-            ("\n →\t", "{lineFeed} →{tab}"),
+            ("\u{000A1338}A\u{000A1339}", "<BON:unassigned unicode='A1338'/>A<BON:unassigned unicode='A1339'/>"),
+            ("neonسلام🚲\u{000A1338}₫\u{000A1339}", "neonسلام🚲<BON:unassigned unicode='A1338'/>₫<BON:unassigned unicode='A1339'/>"),
+            ("\n →\t", "<BON:lineFeed/> →<BON:tab/>"),
         ]
         for (index, testCase) in testCases.enumerated() {
             let line = UInt(#line - testCases.count - 2 + index)
@@ -36,7 +36,7 @@ class NSAttributedStringDebugTests: XCTestCase {
     }
 
     func testImageRepresentationHasSize() {
-        XCTAssertEqual(imageForTest.attributedString().debugRepresentation.string, "{image36x36}")
+        XCTAssertEqual(imageForTest.attributedString().debugRepresentation.string, "<BON:image size='36x36'/>       ")
     }
 
     func testThatNSAttributedStringSpeaksUTF16() {


### PR DESCRIPTION
Hey @ZevEisenberg -- I fixed the bug with debugRepresentation. This should resolve #146 and #197. The one thing that isn't ideal is the generated XML for unassigned unicode characters isn't imported back into the unassigned unicode character.  We could add support for this by having Special have associated values but it would be a good chunk of code churn for a feature I don't think anyone will ever want.