### PR TITLE
Adds `.styled(StringStyle)` part and `styled(with:overrideParts:)`

### DIFF
--- a/Sources/Composable.swift
+++ b/Sources/Composable.swift
@@ -38,6 +38,17 @@ public extension Composable {
         return string
     }
 
+
+    /// Create a new NSAttributedString with the base style specified, overriden by any additional parts.
+    ///
+    /// - parameter style:         The style to decorate with
+    /// - parameter overrideParts: The style parts to override the base style with
+    ///
+    /// - returns: A new NSAttributedString
+    public func styled(with style: StringStyle, _ overrideParts: StylePart...) -> NSAttributedString {
+        return styled(with: style.byAdding(stringStyle: StringStyle(overrideParts)))
+    }
+
     /// Create a new NSAttributedString with the style parts specified
     ///
     /// - parameter parts: The style parts to decorate with

--- a/Sources/StylePart.swift
+++ b/Sources/StylePart.swift
@@ -61,6 +61,13 @@ extension StringStyle {
     ///
     /// - Parameter parts: An array of `StylePart`s
     public init(_ parts: StylePart...) {
+        self.init(parts)
+    }
+
+    /// Create a `StringStyle` from an array of parts
+    ///
+    /// - Parameter parts: An array of `StylePart`s
+    public init(_ parts: [StylePart]) {
         self.init()
         for part in parts {
             self.update(part: part)

--- a/Sources/StylePart.swift
+++ b/Sources/StylePart.swift
@@ -51,6 +51,8 @@ public enum StylePart {
     case adapt(AdaptiveStyle)
     #endif
 
+    // An advanced part that allows combining multiple parts as a single part
+    case style(StringStyle)
 }
 
 extension StringStyle {
@@ -160,6 +162,8 @@ extension StringStyle {
             self.xmlStyler = XMLRuleStyler(rules: rules)
         case let .xmlStyler(xmlStyler):
             self.xmlStyler = xmlStyler
+        case let .style(style):
+            self.add(stringStyle: style)
         default:
             // #if and enum's are disapointing. This case is in default: to remove a warning that default won't be accessed on some platforms.
             if case let .hyphenationFactor(hyphenationFactor) = stylePart {

--- a/Tests/AttributedStringStyleTests.swift
+++ b/Tests/AttributedStringStyleTests.swift
@@ -272,4 +272,15 @@ class StringStyleTests: XCTestCase {
         return [(style: style, fullStyle: false), (style: emptyStyle, fullStyle: false), (style: updated, fullStyle: true)]
     }
 
+    func testStyleStylePart() {
+        let baseStyle = StringStyle(.font(.fontA), .color(.colorA), .backgroundColor(.colorB))
+        let style = StringStyle(.style(baseStyle), .font(.fontB), .color(.colorB))
+
+        let font = style.attributes[NSFontAttributeName] as? BONFont
+        XCTAssertEqual(font?.fontName, BONFont.fontB.fontName)
+        XCTAssertEqual(font?.pointSize, BONFont.fontB.pointSize)
+        BONAssert(attributes: style.attributes, key: NSForegroundColorAttributeName, value: BONColor.colorB)
+        BONAssert(attributes: style.attributes, key: NSBackgroundColorAttributeName, value: BONColor.colorB)
+    }
+
 }


### PR DESCRIPTION
Based on conversation here: https://github.com/Raizlabs/BonMot/pull/228

I ended up still having to implement a `[T]` version `StringStyle(_:StylePart...)` in order to be able to create `styled(with:overrideParts:)`, but let me know if there is another way to do this I'm missing.