### PR TITLE
248 rename adapt(to:) to adapted(to:)

### DIFF
--- a/Example-iOS/StyleViewController.swift
+++ b/Example-iOS/StyleViewController.swift
@@ -46,7 +46,7 @@ class StyleViewController: UITableViewController {
             fatalError("Misconfigured VC")
         }
         let attributedText = styles[indexPath.section].1[indexPath.row]
-        cell.titleLabel?.attributedText = attributedText.adapt(to: traitCollection)
+        cell.titleLabel?.attributedText = attributedText.adapted(to: traitCollection)
         cell.accessoryType = attributedText.attribute("Storyboard", at: 0, effectiveRange: nil) == nil ? .none : .disclosureIndicator
         return cell
     }

--- a/Sources/UIKit/AdaptableTextContainer.swift
+++ b/Sources/UIKit/AdaptableTextContainer.swift
@@ -41,7 +41,7 @@ extension UILabel: AdaptableTextContainer {
             font = attributes[NSFontAttributeName] as? BONFont
         }
         if let attributedText = attributedText {
-            self.attributedText = attributedText.adapt(to: traitCollection)
+            self.attributedText = attributedText.adapted(to: traitCollection)
         }
     }
 
@@ -55,7 +55,7 @@ extension UITextView: AdaptableTextContainer {
     @objc(bon_updateTextForTraitCollection:)
     public func adaptText(forTraitCollection traitCollection: UITraitCollection) {
         if let attributedText = attributedText {
-            self.attributedText = attributedText.adapt(to: traitCollection)
+            self.attributedText = attributedText.adapted(to: traitCollection)
         }
         self.typingAttributes = NSAttributedString.adapt(attributes: typingAttributes, to: traitCollection)
     }
@@ -74,14 +74,14 @@ extension UITextField: AdaptableTextContainer {
     /// - parameter traitCollection: The new trait collection.
     @objc(bon_updateTextForTraitCollection:)
     public func adaptText(forTraitCollection traitCollection: UITraitCollection) {
-        if let attributedText = attributedText?.adapt(to: traitCollection) {
+        if let attributedText = attributedText?.adapted(to: traitCollection) {
             if attributedText.length > 0 {
                 font = attributedText.attribute(NSFontAttributeName, at: 0, effectiveRange: nil) as? UIFont
             }
             self.attributedText = attributedText
         }
         if let attributedPlaceholder = attributedPlaceholder {
-            self.attributedPlaceholder = attributedPlaceholder.adapt(to: traitCollection)
+            self.attributedPlaceholder = attributedPlaceholder.adapted(to: traitCollection)
         }
         defaultTextAttributes = NSAttributedString.adapt(attributes: defaultTextAttributes, to: traitCollection)
         // Fix an issue where shrinking or growing text would stay the same width, but add whitespace.
@@ -99,10 +99,10 @@ extension UIButton: AdaptableTextContainer {
     public func adaptText(forTraitCollection traitCollection: UITraitCollection) {
         for state in UIControlState.commonStates {
             #if swift(>=3.0)
-                let attributedText = attributedTitle(for: state)?.adapt(to: traitCollection)
+                let attributedText = attributedTitle(for: state)?.adapted(to: traitCollection)
                 setAttributedTitle(attributedText, for: state)
             #else
-                let attributedText = attributedTitleForState(state)?.adapt(to: traitCollection)
+                let attributedText = attributedTitleForState(state)?.adapted(to: traitCollection)
                 setAttributedTitle(attributedText, forState: state)
             #endif
         }

--- a/Sources/UIKit/AdaptiveStyleTransformation.swift
+++ b/Sources/UIKit/AdaptiveStyleTransformation.swift
@@ -11,7 +11,7 @@ import UIKit
 /// Defines a style transformation that is dependent on a `UITraitCollection`.
 /// An adaptive transformation is embedded in the `StyleAttributes` so that any
 /// `NSAttributedString` can be updated to a new trait collection using
-/// `attributedString.adapt(to: traitCollection)`.
+/// `attributedString.adapted(to: traitCollection)`.
 ///
 /// Since `NSAttributedString` conforms to `NSCoding`, `AdaptiveStyleTransformation`
 /// is embedded in the `StyleAttributes` via simple dictionary encoding.

--- a/Sources/UIKit/NSAttributedString+Adaptive.swift
+++ b/Sources/UIKit/NSAttributedString+Adaptive.swift
@@ -33,7 +33,7 @@ extension NSAttributedString {
     /// - Parameter traitCollection: The trait collection to adapt to.
     /// - Returns: A new `NSAttributedString` with the style updated to the new
     ///            trait collection.
-    public final func adapt(to traitCollection: UITraitCollection) -> NSAttributedString {
+    public final func adapted(to traitCollection: UITraitCollection) -> NSAttributedString {
         let newString = mutableStringCopy()
         newString.beginEditing()
         enumerateAttributes(in: NSRange(location: 0, length: length), options: []) { (attributes, range, stop) in
@@ -66,5 +66,20 @@ extension StringStyle {
     public func attributes(adaptedTo traitCollection: UITraitCollection) -> StyleAttributes {
         return NSAttributedString.adapt(attributes: attributes, to: traitCollection)
     }
+
+}
+
+// MARK: - Deprecations
+extension NSAttributedString {
+
+    #if swift(>=3.0)
+        @available(*, deprecated, renamed: "adapted(to:)") public final func adapt(to traitCollection: UITraitCollection) -> NSAttributedString {
+            return adapted(to: traitCollection)
+        }
+    #else
+        @available(*, deprecated, renamed="adapted(to:)") public final func adapt(to traitCollection: UITraitCollection) -> NSAttributedString {
+            return adapted(to: traitCollection)
+        }
+    #endif
 
 }

--- a/Sources/UIKit/StyleableUIElement.swift
+++ b/Sources/UIKit/StyleableUIElement.swift
@@ -217,7 +217,7 @@ internal extension StyleableUIElement {
     final func styledAttributedString(from text: String?) -> NSAttributedString? {
         guard let text = text else { return nil }
         let string = (bonMotStyle ?? StringStyle()).attributedString(from: text)
-        return string.adapt(to: traitCollection)
+        return string.adapted(to: traitCollection)
     }
 
     final func lookUpSharedStyle(for name: String?, font: UIFont) -> StringStyle? {

--- a/Tests/AdaptiveStyleTests.swift
+++ b/Tests/AdaptiveStyleTests.swift
@@ -220,9 +220,9 @@ class AdaptiveStyleTests: XCTestCase {
         let style = StringStyle(.font(BONFont(name: "EBGaramond12-Regular", size: 20)!), .numberSpacing(.monospaced), .adapt(.control))
         let tabTestL = NSAttributedString.composed(of: ["Q", Tab.headIndent(10)], baseStyle: style)
         XCTAssertEqualWithAccuracy(firstTabLocation(attributedString: tabTestL), 26.12, accuracy: 0.01)
-        let tabTestXS = tabTestL.adapt(to: UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory.extraSmall.compatible))
+        let tabTestXS = tabTestL.adapted(to: UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory.extraSmall.compatible))
         XCTAssertEqualWithAccuracy(firstTabLocation(attributedString: tabTestXS), 23.70, accuracy: 0.01)
-        let tabTestXXXL = tabTestL.adapt(to: UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory.extraExtraExtraLarge.compatible))
+        let tabTestXXXL = tabTestL.adapted(to: UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory.extraExtraExtraLarge.compatible))
         XCTAssertEqualWithAccuracy(firstTabLocation(attributedString: tabTestXXXL), 30.95, accuracy: 0.01)
     }
 


### PR DESCRIPTION
Closes #248.