### PR TITLE
Accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ DerivedData
 *.hmap
 *.ipa
 
+# AppCode
+.idea
+
 # Bundler
 .bundle
 vendor

--- a/BonMot.podspec
+++ b/BonMot.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "BonMot"
-  s.version          = "4.0.1"
+  s.version          = "4.0.2"
   s.summary          = "Beautiful, easy attributed strings in Swift"
   s.description      = <<-DESC
   BonMot removes all the mystery from creating beautiful, powerful attributed strings in Swift.

--- a/Example-iOS/DemoStrings.swift
+++ b/Example-iOS/DemoStrings.swift
@@ -97,7 +97,7 @@ enum DemoStrings {
 
     static let imagesExample: NSAttributedString = {
 
-        func accessibleImage(named name:String) -> UIImage {
+        func accessibleImage(named name: String) -> UIImage {
             let image = UIImage(named: name)!
             image.accessibilityLabel = name
             return image

--- a/Example-iOS/DemoStrings.swift
+++ b/Example-iOS/DemoStrings.swift
@@ -32,7 +32,10 @@ enum DemoStrings {
         let localizedString = "I want to be different. If everyone is wearing <black><BON:noBreakSpace/>black,<BON:noBreakSpace/></black> I want to be wearing <red><BON:noBreakSpace/>red.<BON:noBreakSpace/></red>\n<signed><BON:emDash/>Maria Sharapova</signed> <racket/>"
 
         // Define a colored image that's slightly shifted to account for the line height
-        let racket = UIImage(named: "Tennis Racket")!.styled(with:
+        let accessibleRacketImage = UIImage(named: "Tennis Racket")!
+        // The racket is purely for decoration, so make the accessibility system ignore it
+        accessibleRacketImage.accessibilityLabel = ""
+        let racket = accessibleRacketImage.styled(with:
             .color(.raizlabsRed), .baselineOffset(-4.0))
 
         // Define styles
@@ -65,7 +68,9 @@ enum DemoStrings {
     /// composition only if you absolutely need to build the string from pieces.
     static let compositionExample: NSAttributedString = {
         // Define a colored image that's slightly shifted to account for the line height
-        let boat = UIImage(named: "boat")!.styled(with:
+        let accessibleBoatImage = UIImage(named: "boat")!
+        accessibleBoatImage.accessibilityLabel = "boat"
+        let boat = accessibleBoatImage.styled(with:
             .color(.raizlabsRed))
 
         let baseStyle = StringStyle(
@@ -90,17 +95,30 @@ enum DemoStrings {
             ], baseStyle: baseStyle)
     }()
 
-    static let imagesExample = NSAttributedString.composed(of: [
-        "2".styled(with: .baselineOffset(8)),
-        UIImage(named: "bee")!,
-        UIImage(named: "oar")!,
-        UIImage(named: "knot")!,
-        "2".styled(with: .baselineOffset(8)),
-        UIImage(named: "bee")!,
+    static let imagesExample: NSAttributedString = {
+
+        func accessibleImage(named name:String) -> UIImage {
+            let image = UIImage(named: name)!
+            image.accessibilityLabel = name
+            return image
+        }
+
+        let bee = accessibleImage(named: "bee")
+        let oar = accessibleImage(named: "oar")
+        let knot = accessibleImage(named: "knot")
+
+        return NSAttributedString.composed(of: [
+            "2".styled(with: .baselineOffset(8)),
+            bee,
+            oar,
+            knot,
+            "2".styled(with: .baselineOffset(8)),
+            bee,
         ], baseStyle: StringStyle(
             .font(UIFont(name: "HelveticaNeue-Bold", size: 24)!),
             .adapt(.control)
         ))
+    }()
 
     static let noBreakSpaceExample: NSAttributedString = {
         let noSpaceTextStyle = StringStyle(

--- a/Sources/Image+Tinting.swift
+++ b/Sources/Image+Tinting.swift
@@ -64,6 +64,9 @@ public extension BONImage {
         // Prevent further tinting
         image.isTemplate = false
 
+        // Transfer accessibility label
+        image.accessibilityLabel = self.accessibilityLabel
+
         return image
     }
     #else
@@ -112,6 +115,9 @@ public extension BONImage {
         if !UIEdgeInsetsEqualToEdgeInsets(originalCapInsets, image.capInsets) || originalResizingMode != image.resizingMode {
             image = image.resizableImage(withCapInsets: originalCapInsets, resizingMode: originalResizingMode)
         }
+
+        // Transfer accessibility label
+        image.accessibilityLabel = self.accessibilityLabel
 
         return image
     }

--- a/Sources/Image+Tinting.swift
+++ b/Sources/Image+Tinting.swift
@@ -64,8 +64,8 @@ public extension BONImage {
         // Prevent further tinting
         image.isTemplate = false
 
-        // Transfer accessibility label
-        image.accessibilityLabel = self.accessibilityLabel
+        // Transfer accessibility description
+        image.accessibilityDescription = self.accessibilityDescription
 
         return image
     }
@@ -116,8 +116,10 @@ public extension BONImage {
             image = image.resizableImage(withCapInsets: originalCapInsets, resizingMode: originalResizingMode)
         }
 
-        // Transfer accessibility label
+        // Transfer accessibility label (iOS only; watchOS does not have accessibilityLabel on UIImage).
+        #if os(iOS)
         image.accessibilityLabel = self.accessibilityLabel
+        #endif
 
         return image
     }

--- a/Sources/Image+Tinting.swift
+++ b/Sources/Image+Tinting.swift
@@ -116,9 +116,9 @@ public extension BONImage {
             image = image.resizableImage(withCapInsets: originalCapInsets, resizingMode: originalResizingMode)
         }
 
-        // Transfer accessibility label (iOS only; watchOS does not have accessibilityLabel on UIImage).
-        #if os(iOS)
-        image.accessibilityLabel = self.accessibilityLabel
+        // Transfer accessibility label (watchOS not included; does not have accessibilityLabel on UIImage).
+        #if os(iOS) || os(tvOS)
+            image.accessibilityLabel = self.accessibilityLabel
         #endif
 
         return image

--- a/Tests/ImageTintingTests.swift
+++ b/Tests/ImageTintingTests.swift
@@ -24,7 +24,7 @@ class ImageTintingTests: XCTestCase {
         let imageForTest = UIImage(named: "rz-logo-black", in: testBundle, compatibleWith: nil)!
         let raizlabsRed = UIColor(red: 0.92549, green: 0.352941, blue: 0.301961, alpha: 1.0)
     #endif
-    
+
     let accessibilityDescription = "I’m the very model of a modern accessible image."
 
     func testImageTinting() {
@@ -67,7 +67,7 @@ class ImageTintingTests: XCTestCase {
         XCTAssertNotNil(tintedResult)
 
         BONAssertNotEqualImages(untintedResult!, tintedResult!)
-    }   
+    }
 
     func testNotTintingInAttributedString() {
         let untintedString = NSAttributedString.composed(of: [
@@ -86,9 +86,9 @@ class ImageTintingTests: XCTestCase {
 
         BONAssertEqualImages(untintedResult!, tintAttemptResult!)
     }
-    
-    func testAccessibilityIOS() {
-        #if os(iOS)
+
+    func testAccessibilityIOSAndTVOS() {
+        #if os(iOS) || os(tvOS)
             imageForTest.accessibilityLabel = accessibilityDescription
             let tintedImage = imageForTest.tintedImage(color: raizlabsRed)
             XCTAssertEqual(tintedImage.accessibilityLabel, accessibilityDescription)
@@ -96,13 +96,12 @@ class ImageTintingTests: XCTestCase {
         #endif
     }
 
-    func testAccessibilityMacOS() {
-        #if os(macOS)
+    func testAccessibilityOSX() {
+        #if os(OSX)
             imageForTest.accessibilityDescription = accessibilityDescription
             let tintedImage = imageForTest.tintedImage(color: raizlabsRed)
             XCTAssertEqual(tintedImage.accessibilityDescription, accessibilityDescription)
             XCTAssertEqual(tintedImage.accessibilityDescription, tintedImage.accessibilityDescription)
         #endif
     }
-
 }

--- a/Tests/ImageTintingTests.swift
+++ b/Tests/ImageTintingTests.swift
@@ -87,7 +87,7 @@ class ImageTintingTests: XCTestCase {
 
     func testAccessibilityLabelTransferToTintedImage() {
         let accessibilityLabel = "I’m the very model of a modern accessible image."
-        let accessibleImage = UIImage(cgImage: imageForTest.cgImage!)
+        let accessibleImage = BONImage(cgImage: imageForTest.cgImage!)
         accessibleImage.accessibilityLabel = accessibilityLabel
         let tintedImage = accessibleImage.tintedImage(color: raizlabsRed)
 

--- a/Tests/ImageTintingTests.swift
+++ b/Tests/ImageTintingTests.swift
@@ -85,4 +85,13 @@ class ImageTintingTests: XCTestCase {
         BONAssertEqualImages(untintedResult!, tintAttemptResult!)
     }
 
+    func testAccessibilityLabelTransferToTintedImage() {
+        let accessibilityLabel = "I’m the very model of a modern accessible image."
+        let accessibleImage = UIImage(cgImage: imageForTest.cgImage!)
+        accessibleImage.accessibilityLabel = accessibilityLabel
+        let tintedImage = accessibleImage.tintedImage(color: raizlabsRed)
+
+        XCTAssertEqual(tintedImage.accessibilityLabel, accessibilityLabel)
+        XCTAssertEqual(tintedImage.accessibilityLabel, accessibleImage.accessibilityLabel)
+    }
 }

--- a/Tests/ImageTintingTests.swift
+++ b/Tests/ImageTintingTests.swift
@@ -24,6 +24,8 @@ class ImageTintingTests: XCTestCase {
         let imageForTest = UIImage(named: "rz-logo-black", in: testBundle, compatibleWith: nil)!
         let raizlabsRed = UIColor(red: 0.92549, green: 0.352941, blue: 0.301961, alpha: 1.0)
     #endif
+    
+    let accessibilityDescription = "I’m the very model of a modern accessible image."
 
     func testImageTinting() {
         let blackImageName = "rz-logo-black"
@@ -65,7 +67,7 @@ class ImageTintingTests: XCTestCase {
         XCTAssertNotNil(tintedResult)
 
         BONAssertNotEqualImages(untintedResult!, tintedResult!)
-    }
+    }   
 
     func testNotTintingInAttributedString() {
         let untintedString = NSAttributedString.composed(of: [
@@ -84,14 +86,23 @@ class ImageTintingTests: XCTestCase {
 
         BONAssertEqualImages(untintedResult!, tintAttemptResult!)
     }
-
-    func testAccessibilityLabelTransferToTintedImage() {
-        let accessibilityLabel = "I’m the very model of a modern accessible image."
-        let accessibleImage = BONImage(cgImage: imageForTest.cgImage!)
-        accessibleImage.accessibilityLabel = accessibilityLabel
-        let tintedImage = accessibleImage.tintedImage(color: raizlabsRed)
-
-        XCTAssertEqual(tintedImage.accessibilityLabel, accessibilityLabel)
-        XCTAssertEqual(tintedImage.accessibilityLabel, accessibleImage.accessibilityLabel)
+    
+    func testAccessibilityIOS() {
+        #if os(iOS)
+            imageForTest.accessibilityLabel = accessibilityDescription
+            let tintedImage = imageForTest.tintedImage(color: raizlabsRed)
+            XCTAssertEqual(tintedImage.accessibilityLabel, accessibilityDescription)
+            XCTAssertEqual(tintedImage.accessibilityLabel, tintedImage.accessibilityLabel)
+        #endif
     }
+
+    func testAccessibilityMacOS() {
+        #if os(macOS)
+            imageForTest.accessibilityDescription = accessibilityDescription
+            let tintedImage = imageForTest.tintedImage(color: raizlabsRed)
+            XCTAssertEqual(tintedImage.accessibilityDescription, accessibilityDescription)
+            XCTAssertEqual(tintedImage.accessibilityDescription, tintedImage.accessibilityDescription)
+        #endif
+    }
+
 }


### PR DESCRIPTION
The demo strings in the iOS Examples app are currently not accessible.

Specifically:

- The XML example has a decorative image that is visible to the accessibility system and shouldn’t be.
- The Composition example has a content image without alternative text.
- The Images & Special characters example has content images without alternative text.

Furthermore, there is a bug in the `tintedImage(color:)` method in the `BONImage` extension that loses the accessibility label on the original image.

This pull request:

1. Fixes the `tintedImage(color:)` method in the `BONImage` extension so that the resulting tinted image has the same accessibility label as the original image.
2. Adds accessibility support to the images in the iOS Example app.
3. (Minor) Adds the .idea folder added to projects by AppCode to .gitignore.

Regarding the second point, the difference in experience of a person using the iOS Example app with VoiceOver is the following:

![img_5887](https://cloud.githubusercontent.com/assets/41798/22254729/b77b4bca-e255-11e6-9d11-12945a7f6abf.PNG)

### XML example

**Before:** Maria Sharapova attachment png, crisp, very dark, file

**After:** Maria Sharapova

* * *

### Composition:

**Before:** You’re going to need a bigger attachment, png, crisp, dark, file

**After:** You’re going to need a bigger boat

* * *

### Images & Special Characters:

**Before:** 2 2

**After:** 2 bee oar knot 2 bee