### PR TITLE
Overriding styles on attributed strings

### DIFF
--- a/Sources/Composable.swift
+++ b/Sources/Composable.swift
@@ -98,6 +98,19 @@ public extension NSAttributedString {
         return string
     }
 
+    public func styled(with style: StringStyle, _ overrideParts: StringStyle.Part...) -> NSAttributedString {
+        let newStyle = style.byAdding(overrideParts)
+        let newAttributes = newStyle.attributes
+
+        let mutableSelf = mutableStringCopy()
+        let fullRange = NSRange(location: 0, length: mutableSelf.string.utf16.count)
+
+        for (key, value) in newAttributes {
+            mutableSelf.addAttribute(key, value: value, range: fullRange)
+        }
+        return mutableSelf.immutableCopy()
+    }
+
 }
 
 extension NSAttributedString: Composable {

--- a/Sources/MutableCopying.swift
+++ b/Sources/MutableCopying.swift
@@ -23,6 +23,12 @@ extension NSAttributedString {
         return copy
     }
 
+    @nonobjc func immutableCopy() -> NSAttributedString {
+        guard let copy = copy() as? NSAttributedString else {
+            fatalError("Failed to copy() \(self)")
+        }
+        return copy
+    }
 }
 
 extension NSParagraphStyle {

--- a/Sources/StringStyle+Part.swift
+++ b/Sources/StringStyle+Part.swift
@@ -137,6 +137,15 @@ extension StringStyle {
     /// - Parameter parts: Zero or more `Part`s
     /// - Returns: A newly configured `StringStyle`
     public func byAdding(_ parts: Part...) -> StringStyle {
+        return byAdding(parts)
+    }
+
+    /// Derive a new `StringStyle` based on this style, updated with zero or
+    /// more `Part`s.
+    ///
+    /// - Parameter parts: an array of `Part`s
+    /// - Returns: A newly configured `StringStyle`
+    public func byAdding(_ parts: [Part]) -> StringStyle {
         var style = self
         for part in parts {
             style.update(part: part)

--- a/Tests/AttributedStringStyleTests.swift
+++ b/Tests/AttributedStringStyleTests.swift
@@ -630,5 +630,32 @@ class StringStyleTests: XCTestCase {
         BONAssert(attributes: style.attributes, key: .backgroundColor, value: BONColor.colorB)
     }
 
+    func testOverridingProperties() {
+        // Parent style is white with font A
+        let parentStyle = StringStyle(.font(.fontA), .color(.white))
+        BONAssertEqualFonts(parentStyle.font!, .fontA)
+        XCTAssertEqual(parentStyle.color, .white)
+
+        let parentAttributedString = "foo".styled(with: parentStyle)
+
+        // Child style is black with font A
+        let childStyle = parentStyle.byAdding(.color(.black))
+
+        BONAssertEqualFonts(childStyle.font!, .fontA)
+        XCTAssertEqual(childStyle.color, .black)
+
+        let childAttributedString = parentAttributedString.styled(with: childStyle)
+        let childAttributes = childAttributedString.attributes(at: 0, effectiveRange: nil)
+        if let childFont = childAttributes[.font] as? BONFont {
+            BONAssertEqualFonts(childFont, .fontA)
+        }
+        else {
+            XCTFail("Font should not be nil")
+        }
+
+        // Child attributes should be overridden with black font
+        BONAssert(attributes: childAttributes, key: .foregroundColor, value: BONColor.black)
+    }
+
 }
 //swiftlint:enable file_length


### PR DESCRIPTION
This PR contains a currently-failing test, demonstrating what I believe to be broken behavior. I wanted to run it by @KingOfBrian and others before taking the time to fix it.

- [x] wait for #296 to merge, and then re-target into `master`