### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img width=443 src="Resources/readme-images/BonMot-logo.png" alt="BonMot Logo" />
 
 [![Swift 2.x + 3.0](https://img.shields.io/badge/Swift-2.3%20+%203.0-orange.svg?style=flat)](https://swift.org)
-[![CircleCI](https://img.shields.io/circleci/project/github/Raizlabs/BonMot.svg)](https://circleci.com/gh/Raizlabs/BonMot)
+[![CircleCI](https://img.shields.io/circleci/project/github/Raizlabs/BonMot/master.svg)](https://circleci.com/gh/Raizlabs/BonMot)
 [![Version](https://img.shields.io/cocoapods/v/BonMot.svg?style=flat)](http://cocoapods.org/pods/BonMot)
 [![License](https://img.shields.io/cocoapods/l/BonMot.svg?style=flat)](http://cocoapods.org/pods/BonMot)
 [![Platform](https://img.shields.io/cocoapods/p/BonMot.svg?style=flat)](http://cocoapods.org/pods/BonMot)


### PR DESCRIPTION
Currently README uses badge pointing to default CircleCI png for project, ant that one is showing status of last build. That means when there is a failure in last PR job but master job still passes, badge will be wrong. This changes it to use master branch badge.